### PR TITLE
Perform CRUD operation on Skill Atom

### DIFF
--- a/src/main/java/com/capstone/skill_service/controller/AtomController.java
+++ b/src/main/java/com/capstone/skill_service/controller/AtomController.java
@@ -1,0 +1,111 @@
+package com.capstone.skill_service.controller;
+
+import com.capstone.skill_service.dto.ClientResponseFormatDto;
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.atom.AtomRequestDto;
+import com.capstone.skill_service.dto.atom.AtomResponseDto;
+import com.capstone.skill_service.dto.atom.AtomUpdateRequestDto;
+import com.capstone.skill_service.service.AtomService;
+import com.capstone.skill_service.util.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("atoms")
+@Tag(name = "Atoms Controller", description = "Manage all skill atom's api")
+public class AtomController {
+    private final AtomService atomService;
+
+    @PostMapping()
+    @Operation(summary = "Create skill atom", description = "This end point allows only admin to create a skill atom")
+    public ResponseEntity<ClientResponseFormatDto> createAtom(
+            @Valid @RequestBody AtomRequestDto atomRequestDto
+    ) {
+        AtomResponseDto savedAtom = this.atomService.create(atomRequestDto);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Atom created successfully!")
+                .errors(null)
+                .data(savedAtom)
+                .build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping()
+    @Operation(summary = "Retrieve skill atoms", description = "This end point allows only admin to fetch all skill atoms")
+    public ResponseEntity<ClientResponseFormatDto> fetchAllAtoms(Pageable pageable) {
+        CustomPageResponse<AtomResponseDto> atoms = this.atomService.findAll(pageable);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Fetch all atoms")
+                .errors(null)
+                .data(atoms)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/{atomId}")
+    @Operation(summary = "Retrieve skill atoms", description = "This end point allows only admin to fetch all skill atoms")
+    public ResponseEntity<ClientResponseFormatDto> retrieveSingleAtom(@PathVariable UUID atomId) {
+        AtomResponseDto atom = this.atomService.getAtom(atomId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Atom retrieved successfully")
+                .errors(null)
+                .data(atom)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping(name = "delete_atom", path = "/{id}")
+    @Operation(summary = "Delete Atom",
+            description = "The atom is delete using its id that is passed as parameter")
+    public ResponseEntity<ClientResponseFormatDto> deleteAtom(@PathVariable UUID id){
+        this.atomService.deleteById(id);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Atom deleted successfully!")
+                .errors(null)
+                .data(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/{atomId}")
+    @Operation(summary = "Update skill atom", description = "This end point allows admin to update a skill atom")
+    public ResponseEntity<ClientResponseFormatDto> updateAtom(
+            @Valid @RequestBody AtomUpdateRequestDto atomRequestDto, @PathVariable UUID atomId) {
+        AtomResponseDto updatedAtom = this.atomService.partialUpdate(atomRequestDto, atomId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Atom updated successfully!")
+                .errors(null)
+                .data(updatedAtom)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PutMapping
+    @Operation(summary = "Update skill atom status", description = "This end point allows admin to update a skill atom as a soft delete")
+    public ResponseEntity<ClientResponseFormatDto> updateAtomStatus(
+            @RequestParam UUID id, @RequestParam Status status) {
+        AtomResponseDto updatedAtom = this.atomService.updateStatus(status, id);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Atom status updated successfully!")
+                .errors(null)
+                .data(updatedAtom)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/dto/atom/AtomRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/atom/AtomRequestDto.java
@@ -1,9 +1,7 @@
 package com.capstone.skill_service.dto.atom;
 
 import com.capstone.skill_service.util.Status;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,7 +19,8 @@ public class AtomRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
 
-    @Pattern(regexp = "^[0-9]+$", message = "only digits are allowed")
+    @Min(value = 1, message = "Must be at least 1 hour")
+    @Max(value = 1000, message = "Must not exceed 1000 hours")
     private int estimatedHours;
 
     private String description;

--- a/src/main/java/com/capstone/skill_service/dto/atom/AtomRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/atom/AtomRequestDto.java
@@ -1,7 +1,11 @@
 package com.capstone.skill_service.dto.atom;
 
 import com.capstone.skill_service.util.Status;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/capstone/skill_service/dto/atom/AtomRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/atom/AtomRequestDto.java
@@ -1,0 +1,34 @@
+package com.capstone.skill_service.dto.atom;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AtomRequestDto {
+    @NotBlank(message = "Name is required")
+    @Size(min = 3, message = "Name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    private String name;
+
+    @Pattern(regexp = "^[0-9]+$", message = "only digits are allowed")
+    private int estimatedHours;
+
+    private String description;
+    private String objectives;
+    private Status status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/capstone/skill_service/dto/atom/AtomResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/atom/AtomResponseDto.java
@@ -1,0 +1,27 @@
+package com.capstone.skill_service.dto.atom;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AtomResponseDto {
+    private UUID id;
+    private String name;
+    private String description;
+    private String objectives;
+    private int estimatedHours;
+    private Status status;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/atom/AtomUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/atom/AtomUpdateRequestDto.java
@@ -1,0 +1,32 @@
+package com.capstone.skill_service.dto.atom;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AtomUpdateRequestDto {
+    @Size(min = 3, message = "Name must have at least 3 characters")
+    @Size(min = 3, message = "Name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    private String name;
+
+    @Pattern(regexp = "^[0-9]+$", message = "only digits are allowed")
+    private int estimatedHours;
+
+    private String description;
+    private String objectives;
+    private Status status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/capstone/skill_service/dto/atom/AtomUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/atom/AtomUpdateRequestDto.java
@@ -1,6 +1,8 @@
 package com.capstone.skill_service.dto.atom;
 
 import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -20,7 +22,6 @@ public class AtomUpdateRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
 
-    @Pattern(regexp = "^[0-9]+$", message = "only digits are allowed")
     private int estimatedHours;
 
     private String description;

--- a/src/main/java/com/capstone/skill_service/dto/cluster/ClusterRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/cluster/ClusterRequestDto.java
@@ -21,7 +21,7 @@ public class ClusterRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
 
-    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "type cannot contain numbers")
     private String type;
 
     private String description;

--- a/src/main/java/com/capstone/skill_service/dto/cluster/ClusterUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/cluster/ClusterUpdateRequestDto.java
@@ -19,7 +19,7 @@ public class ClusterUpdateRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
 
-    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "type cannot contain numbers")
     private String type;
 
     private String description;

--- a/src/main/java/com/capstone/skill_service/dto/tag/TagRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/tag/TagRequestDto.java
@@ -21,7 +21,7 @@ public class TagRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
 
-    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "type cannot contain numbers")
     private String type;
 
     private String description;

--- a/src/main/java/com/capstone/skill_service/dto/tag/TagUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/tag/TagUpdateRequestDto.java
@@ -18,7 +18,7 @@ public class TagUpdateRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
 
-    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "type cannot contain numbers")
     private String type;
 
     private String description;

--- a/src/main/java/com/capstone/skill_service/exception/AtomExistsException.java
+++ b/src/main/java/com/capstone/skill_service/exception/AtomExistsException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class AtomExistsException extends AppException{
+    public AtomExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/exception/AtomNotFoundException.java
+++ b/src/main/java/com/capstone/skill_service/exception/AtomNotFoundException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class AtomNotFoundException extends AppException{
+    public AtomNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/exception/GlobalException.java
+++ b/src/main/java/com/capstone/skill_service/exception/GlobalException.java
@@ -8,11 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.NoHandlerFoundException;
-
 import java.nio.file.AccessDeniedException;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,7 +44,6 @@ public class GlobalException {
                 .build();
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
-
 
     @ExceptionHandler(TagNotFoundException.class)
     public ResponseEntity<?> handleTagNotFound(
@@ -150,5 +146,31 @@ public class GlobalException {
                 .build();
 
         return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(AtomNotFoundException.class)
+    public ResponseEntity<?> handleAtomNotFound(
+            AtomNotFoundException exception) {
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Skill Atom Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(AtomExistsException.class)
+    public ResponseEntity<?> handleAtomExists
+            (AtomExistsException exception) {
+
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Skill Atom Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/com/capstone/skill_service/mapper/AtomMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/AtomMapper.java
@@ -1,0 +1,13 @@
+package com.capstone.skill_service.mapper;
+
+import com.capstone.skill_service.dto.atom.AtomRequestDto;
+import com.capstone.skill_service.dto.atom.AtomResponseDto;
+import com.capstone.skill_service.model.SkillAtomEntity;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface AtomMapper {
+    AtomResponseDto toDto(SkillAtomEntity entity);
+    SkillAtomEntity toEntity(AtomRequestDto dto);
+
+}

--- a/src/main/java/com/capstone/skill_service/model/CapsuleAtomMappingEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/CapsuleAtomMappingEntity.java
@@ -1,6 +1,13 @@
 package com.capstone.skill_service.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/capstone/skill_service/model/CapsuleAtomMappingEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/CapsuleAtomMappingEntity.java
@@ -1,0 +1,33 @@
+package com.capstone.skill_service.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "capsule_atoms")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CapsuleAtomMappingEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "skill_capsule_id")
+    private SkillCapsuleEntity capsule;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "skill_atom_id")
+    private SkillAtomEntity atom;
+
+    @Column(nullable = false)
+    private Integer sequenceOrder;
+
+}

--- a/src/main/java/com/capstone/skill_service/model/SkillAtomEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/SkillAtomEntity.java
@@ -1,0 +1,41 @@
+package com.capstone.skill_service.model;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "skill_atoms")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SkillAtomEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(columnDefinition = "TEXT")
+    private String objectives;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private int moodle_section_id; // id from moodle database on section table
+    private int estimated_hours;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/capstone/skill_service/model/SkillCapsuleEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/SkillCapsuleEntity.java
@@ -1,0 +1,47 @@
+package com.capstone.skill_service.model;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "skill_capsules")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SkillCapsuleEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private String category_type;
+    private String difficulty;
+    private int proficiency_level;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @OneToMany(mappedBy = "capsule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CapsuleAtomMappingEntity> skillAtoms = new ArrayList<>();
+
+    private int moodle_course_id; // id from moodle database on course table
+    private int estimated_hours;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/repository/AtomRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/AtomRepository.java
@@ -1,0 +1,13 @@
+package com.capstone.skill_service.repository;
+
+import com.capstone.skill_service.model.SkillAtomEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface AtomRepository extends JpaRepository<SkillAtomEntity, UUID> {
+    Optional<SkillAtomEntity> findByName(String name);
+}

--- a/src/main/java/com/capstone/skill_service/service/AtomService.java
+++ b/src/main/java/com/capstone/skill_service/service/AtomService.java
@@ -15,8 +15,8 @@ public interface AtomService {
     AtomResponseDto create(AtomRequestDto dto);
     Optional<SkillAtomEntity> findByName(String name);
     CustomPageResponse<AtomResponseDto> findAll(Pageable pageable);
-    Optional<SkillAtomEntity> findById(UUID userId);
-    AtomResponseDto getAtom(UUID userId);
+    Optional<SkillAtomEntity> findById(UUID id);
+    AtomResponseDto getAtom(UUID id);
     void deleteById(UUID id);
     AtomResponseDto partialUpdate(AtomUpdateRequestDto dto, UUID id);
     AtomResponseDto updateStatus(Status status, UUID id);

--- a/src/main/java/com/capstone/skill_service/service/AtomService.java
+++ b/src/main/java/com/capstone/skill_service/service/AtomService.java
@@ -1,0 +1,23 @@
+package com.capstone.skill_service.service;
+
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.atom.AtomRequestDto;
+import com.capstone.skill_service.dto.atom.AtomResponseDto;
+import com.capstone.skill_service.dto.atom.AtomUpdateRequestDto;
+import com.capstone.skill_service.model.SkillAtomEntity;
+import com.capstone.skill_service.util.Status;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AtomService {
+    AtomResponseDto create(AtomRequestDto dto);
+    Optional<SkillAtomEntity> findByName(String name);
+    CustomPageResponse<AtomResponseDto> findAll(Pageable pageable);
+    Optional<SkillAtomEntity> findById(UUID userId);
+    AtomResponseDto getAtom(UUID userId);
+    void deleteById(UUID id);
+    AtomResponseDto partialUpdate(AtomUpdateRequestDto dto, UUID id);
+    AtomResponseDto updateStatus(Status status, UUID id);
+}

--- a/src/main/java/com/capstone/skill_service/service/ClusterService.java
+++ b/src/main/java/com/capstone/skill_service/service/ClusterService.java
@@ -15,8 +15,8 @@ public interface ClusterService {
     ClusterResponseDto create(ClusterRequestDto dto);
     Optional<ClusterEntity> findByName(String name);
     CustomPageResponse<ClusterResponseDto> findAll(Pageable pageable);
-    Optional<ClusterEntity> findById(UUID userId);
-    ClusterResponseDto getCluster(UUID userId);
+    Optional<ClusterEntity> findById(UUID id);
+    ClusterResponseDto getCluster(UUID id);
     void deleteById(UUID id);
     ClusterResponseDto partialUpdate(ClusterUpdateRequestDto dto, UUID id);
     ClusterResponseDto updateStatus(Status status, UUID id);

--- a/src/main/java/com/capstone/skill_service/service/TagService.java
+++ b/src/main/java/com/capstone/skill_service/service/TagService.java
@@ -16,8 +16,8 @@ public interface TagService {
     TagResponseDto create(TagRequestDto dto);
     Optional<TagEntity> findByName(String name);
     CustomPageResponse<TagResponseDto> findAll(Pageable pageable);
-    Optional<TagEntity> findById(UUID userId);
-    TagResponseDto getTag(UUID userId);
+    Optional<TagEntity> findById(UUID id);
+    TagResponseDto getTag(UUID id);
     void deleteById(UUID id);
     TagResponseDto partialUpdate(TagUpdateRequestDto dto, UUID id);
     TagResponseDto updateStatus(Status status, UUID id);

--- a/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
@@ -77,7 +77,7 @@ public class AtomServiceImpl implements AtomService {
     @Override
     public AtomResponseDto getAtom(UUID id) {
         SkillAtomEntity atom = findById(id)
-                .orElseThrow( () -> new AtomNotFoundException("A atom provided doesn't exist")
+                .orElseThrow( () -> new AtomNotFoundException("A Skill atom provided doesn't exist")
                 );
 
         logger.info("Skill atom {} retrieved", atom.getName());
@@ -88,7 +88,7 @@ public class AtomServiceImpl implements AtomService {
     @Override
     public void deleteById(UUID id) {
         SkillAtomEntity atom = findById(id)
-                .orElseThrow( () -> new AtomNotFoundException("A atom provided doesn't exist")
+                .orElseThrow( () -> new AtomNotFoundException("A Skill atom provided doesn't exist")
                 );
 
         logger.info("Skill atom {} deleted", atom.getName());
@@ -98,14 +98,35 @@ public class AtomServiceImpl implements AtomService {
 
     @Override
     public AtomResponseDto partialUpdate(AtomUpdateRequestDto dto, UUID id) {
-        //TODO
-        return null;
+        SkillAtomEntity atom = findById(id)
+                .orElseThrow( () -> new AtomNotFoundException("A Skill atom provided doesn't exist")
+                );
+        if(dto.getName() != null){
+            atom.setName(dto.getName());
+        }
+        if(dto.getObjectives() != null){
+            atom.setObjectives(dto.getObjectives());
+        }
+        if(dto.getDescription() != null){
+            atom.setDescription(dto.getDescription());
+        }
+        if(dto.getUpdatedAt() != null){
+            atom.setUpdatedAt(LocalDateTime.now());
+        }
+
+        logger.info("Skill atom {} updated", atom.getName());
+
+        return this.atomMapper.toDto(this.atomRepository.save(atom));
     }
 
     @Override
     public AtomResponseDto updateStatus(Status status, UUID id) {
-        //TODO
-        return null;
+        SkillAtomEntity atom = findById(id)
+                .orElseThrow( () -> new AtomNotFoundException("A Skill atom provided doesn't exist")
+                );
+        atom.setStatus(status);
+
+        return this.atomMapper.toDto(this.atomRepository.save(atom));
     }
 
 }

--- a/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
@@ -53,8 +53,20 @@ public class AtomServiceImpl implements AtomService {
 
     @Override
     public CustomPageResponse<AtomResponseDto> findAll(Pageable pageable) {
-        //TODO
-        return null;
+        Page<SkillAtomEntity> atomList = this.atomRepository.findAll(pageable);
+        Page<AtomResponseDto> atoms = atomList.map(this.atomMapper::toDto);
+
+        logger.info("Atoms list is fetched");
+
+        return CustomPageResponse.<AtomResponseDto>builder()
+                .items(atoms.getContent())
+                .page(atoms.getNumber())
+                .size(atoms.getSize())
+                .totalElements(atoms.getTotalElements())
+                .totalPages(atoms.getTotalPages())
+                .hasNext(atoms.hasNext())
+                .hasPrevious(atoms.hasPrevious())
+                .build();
     }
 
     @Override
@@ -63,9 +75,14 @@ public class AtomServiceImpl implements AtomService {
     }
 
     @Override
-    public AtomResponseDto getAtom(UUID userId) {
-        //TODO
-        return null;
+    public AtomResponseDto getAtom(UUID id) {
+        SkillAtomEntity atom = findById(id)
+                .orElseThrow( () -> new AtomNotFoundException("A atom provided doesn't exist")
+                );
+
+        logger.info("Skill atom {} retrieved", atom.getName());
+
+        return this.atomMapper.toDto(atom);
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
@@ -1,0 +1,94 @@
+package com.capstone.skill_service.service.impl;
+
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.atom.AtomRequestDto;
+import com.capstone.skill_service.dto.atom.AtomResponseDto;
+import com.capstone.skill_service.dto.atom.AtomUpdateRequestDto;
+import com.capstone.skill_service.exception.AtomExistsException;
+import com.capstone.skill_service.exception.AtomNotFoundException;
+import com.capstone.skill_service.mapper.AtomMapper;
+import com.capstone.skill_service.model.SkillAtomEntity;
+import com.capstone.skill_service.repository.AtomRepository;
+import com.capstone.skill_service.service.AtomService;
+import com.capstone.skill_service.util.Status;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AtomServiceImpl implements AtomService {
+    private static final Logger logger = LoggerFactory.getLogger(AtomServiceImpl.class);
+    private final AtomRepository atomRepository;
+    private final AtomMapper atomMapper;
+
+    @Override
+    public AtomResponseDto create(AtomRequestDto dto) {
+        if(findByName(dto.getName()).isPresent()){
+            throw new AtomExistsException(
+                    String.format("A Skill Atom with the name '%s' already exist",
+                            dto.getName()));
+        }
+        SkillAtomEntity atomEntity = this.atomMapper.toEntity(dto);
+
+        atomEntity.setCreatedAt(LocalDateTime.now());
+        atomEntity.setUpdatedAt(LocalDateTime.now());
+        atomEntity.setStatus(Status.ACTIVE);
+        logger.info("Admin created skill atom: {}", atomEntity.getName());
+
+        return this.atomMapper.toDto(atomRepository.save(atomEntity));
+    }
+
+    @Override
+    public Optional<SkillAtomEntity> findByName(String name) {
+        return this.atomRepository.findByName(name);
+    }
+
+    @Override
+    public CustomPageResponse<AtomResponseDto> findAll(Pageable pageable) {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public Optional<SkillAtomEntity> findById(UUID id) {
+        return this.atomRepository.findById(id);
+    }
+
+    @Override
+    public AtomResponseDto getAtom(UUID userId) {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        SkillAtomEntity atom = findById(id)
+                .orElseThrow( () -> new AtomNotFoundException("A atom provided doesn't exist")
+                );
+
+        logger.info("Skill atom {} deleted", atom.getName());
+
+        this.atomRepository.deleteById(id);
+    }
+
+    @Override
+    public AtomResponseDto partialUpdate(AtomUpdateRequestDto dto, UUID id) {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public AtomResponseDto updateStatus(Status status, UUID id) {
+        //TODO
+        return null;
+    }
+
+}


### PR DESCRIPTION
# 🚀 Pull Request: Perform CRUD operation on Skill Atom

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Implement CRUD Operation on Skill Atom](https://amali-tech.atlassian.net/browse/VER-94)  

---

## ✅ Summary

This PR introduces functionality that allows **admin to create, update, retrieve, and delete skill atom**.

---

## 📌 Features Added

- [x] Atom creation and update
- [x] Atom retrieval with pagination
- [x] Field validation
- [x] Global Exception handling
- [x] Document API using Swagger

---

## 🚧 Next Task

- Create Skill Capsule