### PR TITLE
Growth track creation and retrieval

### DIFF
--- a/src/main/java/com/capstone/skill_service/controller/TrackController.java
+++ b/src/main/java/com/capstone/skill_service/controller/TrackController.java
@@ -1,0 +1,159 @@
+package com.capstone.skill_service.controller;
+
+import com.capstone.skill_service.dto.ClientResponseFormatDto;
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.atom.AtomIdsRequestDto;
+import com.capstone.skill_service.dto.capsule.CapsuleIdsRequestDto;
+import com.capstone.skill_service.dto.cluster.ClusterIdsRequestDto;
+import com.capstone.skill_service.dto.tag.TagIdsRequestDto;
+import com.capstone.skill_service.dto.track.TrackRequestDto;
+import com.capstone.skill_service.dto.track.TrackResponseDto;
+import com.capstone.skill_service.dto.track.TrackUpdateRequestDto;
+import com.capstone.skill_service.service.TrackService;
+import com.capstone.skill_service.util.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("growth-tracks")
+@Tag(name = "Growth Tracks Controller", description = "Manage all growth track's api")
+public class TrackController {
+    private final TrackService trackService;
+
+    @PostMapping()
+    @Operation(summary = "Create growth track", description = "This end point allows only admin to create a growth track")
+    public ResponseEntity<ClientResponseFormatDto> createTrack(
+            @Valid @RequestBody TrackRequestDto trackRequestDto
+    ) {
+        TrackResponseDto savedTrack = this.trackService.create(trackRequestDto);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Track created successfully!")
+                .errors(null)
+                .data(savedTrack)
+                .build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping()
+    @Operation(summary = "Retrieve growth tracks", description = "This end point allows only admin to fetch all growth tracks")
+    public ResponseEntity<ClientResponseFormatDto> fetchAllTracks(Pageable pageable) {
+        CustomPageResponse<TrackResponseDto> tracks = this.trackService.findAll(pageable);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Fetch all growth tracks")
+                .errors(null)
+                .data(tracks)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/{trackId}")
+    @Operation(summary = "Retrieve growth tracks", description = "This end point allows only admin to fetch all growth tracks")
+    public ResponseEntity<ClientResponseFormatDto> retrieveSingleTrack(@PathVariable UUID trackId) {
+        TrackResponseDto track = this.trackService.getTrack(trackId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Track retrieved successfully")
+                .errors(null)
+                .data(track)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping(name = "delete_track", path = "/{id}")
+    @Operation(summary = "Delete Track",
+            description = "The track is deleted using its id that is passed as parameter")
+    public ResponseEntity<ClientResponseFormatDto> deleteTrack(@PathVariable UUID id){
+        this.trackService.deleteById(id);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Growth Track deleted successfully!")
+                .errors(null)
+                .data(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/{trackId}")
+    @Operation(summary = "Update growth track", description = "This end point allows admin to update a growth track")
+    public ResponseEntity<ClientResponseFormatDto> updateTrack(
+            @Valid @RequestBody TrackUpdateRequestDto trackRequestDto, @PathVariable UUID trackId) {
+        TrackResponseDto updatedTrack = this.trackService.partialUpdate(trackRequestDto, trackId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Growth Track updated successfully!")
+                .errors(null)
+                .data(updatedTrack)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PutMapping
+    @Operation(summary = "Update growth track status", description = "This end point allows admin to update a growth track as a soft delete")
+    public ResponseEntity<ClientResponseFormatDto> updateTrackStatus(
+            @RequestParam UUID id, @RequestParam Status status) {
+        TrackResponseDto updatedTrack = this.trackService.updateStatus(status, id);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Growth Track status updated successfully!")
+                .errors(null)
+                .data(updatedTrack)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/assignCapsule/{trackId}")
+    @Operation(summary = "Assign new skill capsule to a growth track", description = "This end point allows admin to add new skill capsule to a growth track")
+    public ResponseEntity<ClientResponseFormatDto> assignCapsuleToTrack(
+            @RequestBody CapsuleIdsRequestDto atomIds, @PathVariable UUID trackId) {
+        TrackResponseDto updatedTrack = this.trackService.assignCapsuleToTrack(trackId, atomIds);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Capsules added to a growth track successfully!")
+                .errors(null)
+                .data(updatedTrack)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping("/removeCapsule")
+    @Operation(summary = "Remove a growth atom from track", description = "This end point allows admin to remove a growth atom from track")
+    public ResponseEntity<ClientResponseFormatDto> removeCapsuleFromTrack(
+            @RequestParam UUID trackId, @RequestParam UUID atomId) {
+        TrackResponseDto updatedTrack = this.trackService.removeCapsuleFromTrack(trackId, atomId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Capsule removed from track successfully!")
+                .errors(null)
+                .data(updatedTrack)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PutMapping("/reorderCapsule/{trackId}")
+    @Operation(summary = "Reorder new skill capsule in a growth track collection", description = "This end point allows admin " +
+            "to shift capsule sequence order in a growth track however they want")
+    public ResponseEntity<ClientResponseFormatDto> reorderCapsule(
+            @RequestBody CapsuleIdsRequestDto atomIds, @PathVariable UUID trackId) {
+        TrackResponseDto updatedTrack = this.trackService.reorderCapsules(trackId, atomIds.getCapsuleIds());
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Capsules reordered in track successfully!")
+                .errors(null)
+                .data(updatedTrack)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+}

--- a/src/main/java/com/capstone/skill_service/controller/TrackController.java
+++ b/src/main/java/com/capstone/skill_service/controller/TrackController.java
@@ -2,13 +2,11 @@ package com.capstone.skill_service.controller;
 
 import com.capstone.skill_service.dto.ClientResponseFormatDto;
 import com.capstone.skill_service.dto.CustomPageResponse;
-import com.capstone.skill_service.dto.atom.AtomIdsRequestDto;
 import com.capstone.skill_service.dto.capsule.CapsuleIdsRequestDto;
-import com.capstone.skill_service.dto.cluster.ClusterIdsRequestDto;
-import com.capstone.skill_service.dto.tag.TagIdsRequestDto;
 import com.capstone.skill_service.dto.track.TrackRequestDto;
 import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.dto.track.TrackUpdateRequestDto;
+import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
 import com.capstone.skill_service.service.TrackService;
 import com.capstone.skill_service.util.Status;
 import io.swagger.v3.oas.annotations.Operation;
@@ -60,7 +58,7 @@ public class TrackController {
     @GetMapping("/{trackId}")
     @Operation(summary = "Retrieve growth tracks", description = "This end point allows only admin to fetch all growth tracks")
     public ResponseEntity<ClientResponseFormatDto> retrieveSingleTrack(@PathVariable UUID trackId) {
-        TrackResponseDto track = this.trackService.getTrack(trackId);
+        TrackWithCapsuleResponseDto track = this.trackService.getTrackWithCapsules(trackId);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .status(true)
                 .message("Track retrieved successfully")

--- a/src/main/java/com/capstone/skill_service/dto/capsule/CapsuleIdsRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/capsule/CapsuleIdsRequestDto.java
@@ -1,0 +1,18 @@
+package com.capstone.skill_service.dto.capsule;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CapsuleIdsRequestDto {
+    private List<UUID> capsuleIds;
+}

--- a/src/main/java/com/capstone/skill_service/dto/capsule/CapsuleInSequenceOrderResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/capsule/CapsuleInSequenceOrderResponseDto.java
@@ -1,0 +1,30 @@
+package com.capstone.skill_service.dto.capsule;
+
+import com.capstone.skill_service.dto.atom.AtomInSequenceOrderResponseDto;
+import com.capstone.skill_service.util.ProficiencyLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CapsuleInSequenceOrderResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private int estimatedHours;
+    private String difficulty;
+    private ProficiencyLevel proficiencyLevel;
+    private String description;
+    List<AtomInSequenceOrderResponseDto> skillAtoms; // list of skill atom in sequence order
+    private int sequenceOrder;
+}

--- a/src/main/java/com/capstone/skill_service/dto/capsule/CapsuleSummaryResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/capsule/CapsuleSummaryResponseDto.java
@@ -1,0 +1,24 @@
+package com.capstone.skill_service.dto.capsule;
+
+import com.capstone.skill_service.util.ProficiencyLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CapsuleSummaryResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private String difficulty;
+    private ProficiencyLevel proficiencyLevel;
+}

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackRequestDto.java
@@ -1,0 +1,33 @@
+package com.capstone.skill_service.dto.track;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrackRequestDto {
+    @NotBlank(message = "Name is required")
+    @Size(min = 3, message = "Name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    private String name;
+
+    @Min(value = 1, message = "Must be at least 1 hour")
+    @Max(value = 1000, message = "Must not exceed 1000 hours")
+    private int estimatedMonths;
+
+    List<UUID> capsuleIds; // list of capsule ids
+    private String description;
+    private Status status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
@@ -27,7 +27,6 @@ public class TrackResponseDto implements Serializable {
     private String description;
     private int estimatedMonths;
     private Status status;
-    private List<CapsuleResponseDto> capsules;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
@@ -1,0 +1,33 @@
+package com.capstone.skill_service.dto.track;
+
+import com.capstone.skill_service.dto.capsule.CapsuleResponseDto;
+import com.capstone.skill_service.util.Status;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+public class TrackResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private String description;
+    private int estimatedMonths;
+    private Status status;
+    private List<CapsuleResponseDto> capsules;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
@@ -1,6 +1,6 @@
 package com.capstone.skill_service.dto.track;
 
-import com.capstone.skill_service.dto.capsule.CapsuleResponseDto;
+import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
 import com.capstone.skill_service.util.Status;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
@@ -27,6 +27,7 @@ public class TrackResponseDto implements Serializable {
     private String description;
     private int estimatedMonths;
     private Status status;
+    private List<CapsuleSummaryResponseDto> capsules;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package com.capstone.skill_service.dto.track;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrackUpdateRequestDto {
+    @Size(min = 3, message = "Name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    private String name;
+    private int estimatedMonths;
+
+    List<UUID> capsuleIds; // list of capsule ids
+    private String description;
+    private Status status;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackWithCapsuleResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackWithCapsuleResponseDto.java
@@ -1,6 +1,8 @@
 package com.capstone.skill_service.dto.track;
 
+import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.capsule.CapsuleResponseDto;
+import com.capstone.skill_service.dto.capsule.CapsuleSummaryWithNoClusterResponseDto;
 import com.capstone.skill_service.util.Status;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
@@ -27,6 +29,6 @@ public class TrackWithCapsuleResponseDto implements Serializable {
     private String description;
     private int estimatedMonths;
     private Status status;
-    private List<CapsuleResponseDto> capsules;
+    private List<CapsuleInSequenceOrderResponseDto> capsules;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackWithCapsuleResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackWithCapsuleResponseDto.java
@@ -1,0 +1,32 @@
+package com.capstone.skill_service.dto.track;
+
+import com.capstone.skill_service.dto.capsule.CapsuleResponseDto;
+import com.capstone.skill_service.util.Status;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+public class TrackWithCapsuleResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private String description;
+    private int estimatedMonths;
+    private Status status;
+    private List<CapsuleResponseDto> capsules;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/capstone/skill_service/exception/GlobalException.java
+++ b/src/main/java/com/capstone/skill_service/exception/GlobalException.java
@@ -225,4 +225,30 @@ public class GlobalException {
                 .build();
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(TrackNotFoundException.class)
+    public ResponseEntity<?> handleTrackNotFound(
+            TrackNotFoundException exception) {
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Growth Track Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(TrackExistsException.class)
+    public ResponseEntity<?> handleTrackExists
+            (TrackExistsException exception) {
+
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Growth Track Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+    }
 }

--- a/src/main/java/com/capstone/skill_service/exception/TrackExistsException.java
+++ b/src/main/java/com/capstone/skill_service/exception/TrackExistsException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class TrackExistsException extends AppException{
+    public TrackExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/exception/TrackNotFoundException.java
+++ b/src/main/java/com/capstone/skill_service/exception/TrackNotFoundException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class TrackNotFoundException extends AppException{
+    public TrackNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/mapper/CapsuleMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/CapsuleMapper.java
@@ -1,11 +1,13 @@
 package com.capstone.skill_service.mapper;
 
 import com.capstone.skill_service.dto.atom.AtomInSequenceOrderResponseDto;
+import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.capsule.CapsuleRequestDto;
 import com.capstone.skill_service.dto.capsule.CapsuleResponseDto;
 import com.capstone.skill_service.dto.capsule.CapsuleSummaryWithNoClusterResponseDto;
 import com.capstone.skill_service.model.CapsuleAtomMappingEntity;
 import com.capstone.skill_service.model.SkillCapsuleEntity;
+import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -31,5 +33,14 @@ public interface CapsuleMapper {
     @Mapping(target = "tags", source = "tags")
     CapsuleSummaryWithNoClusterResponseDto toNoClusterDto(SkillCapsuleEntity entity);
 
+    @Mapping(target = "id", source = "capsule.id")
+    @Mapping(target = "name", source = "capsule.name")
+    @Mapping(target = "estimatedHours", source = "capsule.estimatedHours")
+    @Mapping(target = "difficulty", source = "capsule.difficulty")
+    @Mapping(target = "proficiencyLevel", source = "capsule.proficiencyLevel")
+    @Mapping(target = "description", source = "capsule.description")
+    @Mapping(target = "skillAtoms", source = "capsule.skillAtoms")
+    @Mapping(target = "sequenceOrder", source = "sequenceOrder")
+    CapsuleInSequenceOrderResponseDto toInSequenceOrderDto(TrackCapsuleMappingEntity mapping);
 
 }

--- a/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
@@ -1,0 +1,19 @@
+package com.capstone.skill_service.mapper;
+
+import com.capstone.skill_service.dto.track.TrackRequestDto;
+import com.capstone.skill_service.dto.track.TrackResponseDto;
+import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
+import com.capstone.skill_service.model.GrowthTrackEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface TrackMapper {
+    @Mapping(target = "capsules",  source = "capsules")
+    TrackResponseDto toDto(GrowthTrackEntity entity);
+
+    GrowthTrackEntity toEntity(TrackRequestDto dto);
+    @Mapping(target = "capsules",  ignore = true)
+    TrackWithCapsuleResponseDto toWithCapsuleDto(GrowthTrackEntity entity);
+
+}

--- a/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
@@ -1,18 +1,27 @@
 package com.capstone.skill_service.mapper;
 
+import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
 import com.capstone.skill_service.dto.track.TrackRequestDto;
 import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
 import com.capstone.skill_service.model.GrowthTrackEntity;
+import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface TrackMapper {
+    @Mapping(target = "capsules", source = "skillCapsules")
     TrackResponseDto toDto(GrowthTrackEntity entity);
 
     GrowthTrackEntity toEntity(TrackRequestDto dto);
     @Mapping(target = "capsules",  ignore = true)
     TrackWithCapsuleResponseDto toWithCapsuleDto(GrowthTrackEntity entity);
+
+    @Mapping(target = "id", source = "capsule.id")
+    @Mapping(target = "name", source = "capsule.name")
+    @Mapping(target = "difficulty", source = "capsule.difficulty")
+    @Mapping(target = "proficiencyLevel", source = "capsule.proficiencyLevel")
+    CapsuleSummaryResponseDto mapToCapsuleDto(TrackCapsuleMappingEntity mapping);
 
 }

--- a/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
@@ -9,7 +9,6 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface TrackMapper {
-    @Mapping(target = "capsules",  source = "capsules")
     TrackResponseDto toDto(GrowthTrackEntity entity);
 
     GrowthTrackEntity toEntity(TrackRequestDto dto);

--- a/src/main/java/com/capstone/skill_service/model/GrowthTrackEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/GrowthTrackEntity.java
@@ -1,0 +1,43 @@
+package com.capstone.skill_service.model;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "growth_tracks")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GrowthTrackEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @OneToMany(mappedBy = "growthTrack", cascade = CascadeType.ALL, orphanRemoval = true) // just remove child from growth track list
+    @OrderBy("sequenceOrder ASC") // to always display capsule in sequence order
+    private List<TrackCapsuleMappingEntity> skillCapsules = new ArrayList<>();
+
+    private int estimatedMonths;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/model/TrackCapsuleMappingEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/TrackCapsuleMappingEntity.java
@@ -1,0 +1,33 @@
+package com.capstone.skill_service.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "track_capsules")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrackCapsuleMappingEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "growth_track_id")
+    private GrowthTrackEntity growthTrack;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "skill_capsule_id")
+    private SkillCapsuleEntity capsule;
+
+    @Column(nullable = false)
+    private Integer sequenceOrder;
+
+}

--- a/src/main/java/com/capstone/skill_service/repository/TrackCapsuleMappingRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackCapsuleMappingRepository.java
@@ -1,0 +1,23 @@
+package com.capstone.skill_service.repository;
+
+import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface TrackCapsuleMappingRepository extends JpaRepository<TrackCapsuleMappingEntity, UUID> {
+    @Query("""
+    SELECT tc
+    FROM TrackCapsuleMappingEntity tc
+    JOIN FETCH tc.capsule
+    WHERE tc.growthTrack.id = :trackId
+    ORDER BY tc.growthTrack.id, tc.sequenceOrder
+""")
+    List<TrackCapsuleMappingEntity> findByTrackIdsWithCapsules(@Param("trackId") UUID trackId);
+
+}

--- a/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
@@ -1,11 +1,15 @@
 package com.capstone.skill_service.repository;
 
 import com.capstone.skill_service.model.GrowthTrackEntity;
+import com.capstone.skill_service.model.SkillCapsuleEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,4 +25,10 @@ public interface TrackRepository extends JpaRepository<GrowthTrackEntity, UUID> 
     """)
     Optional<GrowthTrackEntity> findByIdWithCapsules(@Param("id") UUID id);
 
+    @Query("""
+        SELECT gt FROM GrowthTrackEntity gt
+        LEFT JOIN FETCH gt.skillCapsules c
+        ORDER BY gt.createdAt DESC
+    """)
+    Page<GrowthTrackEntity> findAllWithSkillCapsule(Pageable pageable);
 }

--- a/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
@@ -1,0 +1,24 @@
+package com.capstone.skill_service.repository;
+
+import com.capstone.skill_service.model.GrowthTrackEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface TrackRepository extends JpaRepository<GrowthTrackEntity, UUID> {
+    Optional<GrowthTrackEntity> findByName(String name);
+
+    @Query("""
+        SELECT gt
+        FROM GrowthTrackEntity gt
+        LEFT JOIN FETCH gt.skillCapsules c
+        where gt.id = :id
+    """)
+    Optional<GrowthTrackEntity> findByIdWithCapsules(@Param("id") UUID id);
+
+}

--- a/src/main/java/com/capstone/skill_service/service/TrackService.java
+++ b/src/main/java/com/capstone/skill_service/service/TrackService.java
@@ -5,6 +5,7 @@ import com.capstone.skill_service.dto.capsule.CapsuleIdsRequestDto;
 import com.capstone.skill_service.dto.track.TrackRequestDto;
 import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.dto.track.TrackUpdateRequestDto;
+import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
 import com.capstone.skill_service.model.GrowthTrackEntity;
 import com.capstone.skill_service.util.Status;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +20,7 @@ public interface TrackService {
     Optional<GrowthTrackEntity> findById(UUID id);
     CustomPageResponse<TrackResponseDto> findAll(Pageable pageable);
     TrackResponseDto getTrack(UUID id);
+    TrackWithCapsuleResponseDto getTrackWithCapsules(UUID trackId);
     void deleteById(UUID id);
     TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id);
     TrackResponseDto updateStatus(Status status, UUID id);

--- a/src/main/java/com/capstone/skill_service/service/TrackService.java
+++ b/src/main/java/com/capstone/skill_service/service/TrackService.java
@@ -1,0 +1,29 @@
+package com.capstone.skill_service.service;
+
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.capsule.CapsuleIdsRequestDto;
+import com.capstone.skill_service.dto.track.TrackRequestDto;
+import com.capstone.skill_service.dto.track.TrackResponseDto;
+import com.capstone.skill_service.dto.track.TrackUpdateRequestDto;
+import com.capstone.skill_service.model.GrowthTrackEntity;
+import com.capstone.skill_service.util.Status;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TrackService {
+    TrackResponseDto create(TrackRequestDto dto);
+    Optional<GrowthTrackEntity> findByName(String name);
+    Optional<GrowthTrackEntity> findById(UUID id);
+    CustomPageResponse<TrackResponseDto> findAll(Pageable pageable);
+    TrackResponseDto getTrack(UUID id);
+    void deleteById(UUID id);
+    TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id);
+    TrackResponseDto updateStatus(Status status, UUID id);
+    TrackResponseDto assignCapsuleToTrack(UUID trackId, CapsuleIdsRequestDto dto);
+    TrackResponseDto removeCapsuleFromTrack(UUID trackId, UUID capsuleId);
+    TrackResponseDto reorderCapsules(UUID trackId, List<UUID> orderedCapsuleIds);
+
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -1,0 +1,141 @@
+package com.capstone.skill_service.service.impl;
+
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.capsule.CapsuleIdsRequestDto;
+import com.capstone.skill_service.dto.track.TrackRequestDto;
+import com.capstone.skill_service.dto.track.TrackResponseDto;
+import com.capstone.skill_service.dto.track.TrackUpdateRequestDto;
+import com.capstone.skill_service.exception.*;
+import com.capstone.skill_service.mapper.CapsuleMapper;
+import com.capstone.skill_service.mapper.ClusterMapper;
+import com.capstone.skill_service.mapper.TagMapper;
+import com.capstone.skill_service.mapper.TrackMapper;
+import com.capstone.skill_service.model.*;
+import com.capstone.skill_service.repository.*;
+import com.capstone.skill_service.service.TrackService;
+import com.capstone.skill_service.util.Status;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class TrackServiceImpl implements TrackService {
+    private static final Logger logger = LoggerFactory.getLogger(TrackServiceImpl.class);
+    private final CapsuleRepository capsuleRepository;
+    private final CapsuleMapper capsuleMapper;
+    private final TrackRepository trackRepository;
+    private final TrackMapper trackMapper;
+
+
+    @Override
+    public TrackResponseDto create(TrackRequestDto dto) {
+        if(findByName(dto.getName()).isPresent()){
+            throw new TrackExistsException(
+                    String.format("A Growth Track with the name '%s' already exist",
+                            dto.getName()));
+        }
+        GrowthTrackEntity trackEntity = this.trackMapper.toEntity(dto);
+
+        trackEntity.setCreatedAt(LocalDateTime.now());
+        trackEntity.setUpdatedAt(LocalDateTime.now());
+        trackEntity.setStatus(Status.ACTIVE);
+        addCapsulesToTrack(trackEntity, dto.getCapsuleIds()); // link track to all the capsules assigned to
+
+
+        logger.info("Admin created skill track: {}", trackEntity.getName());
+
+        return this.trackMapper.toDto(trackRepository.save(trackEntity));
+
+    }
+
+
+    void addCapsulesToTrack(GrowthTrackEntity trackEntity, List<UUID> capsuleIds){
+        if (trackEntity.getSkillCapsules() == null) {
+            trackEntity.setSkillCapsules(new ArrayList<>());
+        }
+
+        int numberOfCapsulesInCapsule = trackEntity.getSkillCapsules().size();
+
+        for(int i=0; i<capsuleIds.size(); i++){
+            UUID capsuleId=capsuleIds.get(i); //get capsule id
+
+            SkillCapsuleEntity capsule = this.capsuleRepository.findById(capsuleId)
+                    .orElseThrow( () -> new CapsuleNotFoundException("A Skill capsule provided doesn't exist")
+                    );
+
+            boolean alreadyAssignedToCapsule = trackEntity.getSkillCapsules().stream()
+                    .anyMatch(mapping -> mapping.getCapsule().getId().equals(capsuleId));
+
+            if(alreadyAssignedToCapsule){
+                throw new AlreadyAssignedException("Capsule is already assigned to this track");
+            }
+
+            // assign capsule to track
+            TrackCapsuleMappingEntity assignCapsuleToCapsule = TrackCapsuleMappingEntity.builder()
+                    .capsule(capsule)
+                    .growthTrack(trackEntity)
+                    .sequenceOrder(numberOfCapsulesInCapsule + i + 1) // set default sequence order, when child size is 0, order starts from 1 else starts from size number + 1
+                    .build();
+
+            trackEntity.getSkillCapsules().add(assignCapsuleToCapsule);// add a single assignment to assigment collection
+        }
+
+    }
+
+    @Override
+    public Optional<GrowthTrackEntity> findByName(String name) {
+        return this.trackRepository.findByName(name);
+    }
+
+    @Override
+    public Optional<GrowthTrackEntity> findById(UUID id) {
+        return Optional.empty();
+    }
+
+    @Override
+    public CustomPageResponse<TrackResponseDto> findAll(Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public TrackResponseDto getTrack(UUID id) {
+        return null;
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+
+    }
+
+    @Override
+    public TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id) {
+        return null;
+    }
+
+    @Override
+    public TrackResponseDto updateStatus(Status status, UUID id) {
+        return null;
+    }
+
+    @Override
+    public TrackResponseDto assignCapsuleToTrack(UUID trackId, CapsuleIdsRequestDto dto) {
+        return null;
+    }
+
+    @Override
+    public TrackResponseDto removeCapsuleFromTrack(UUID trackId, UUID capsuleId) {
+        return null;
+    }
+
+    @Override
+    public TrackResponseDto reorderCapsules(UUID trackId, List<UUID> orderedCapsuleIds) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -1,14 +1,15 @@
 package com.capstone.skill_service.service.impl;
 
 import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.atom.AtomInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.capsule.CapsuleIdsRequestDto;
+import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.track.TrackRequestDto;
 import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.dto.track.TrackUpdateRequestDto;
+import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
 import com.capstone.skill_service.exception.*;
 import com.capstone.skill_service.mapper.CapsuleMapper;
-import com.capstone.skill_service.mapper.ClusterMapper;
-import com.capstone.skill_service.mapper.TagMapper;
 import com.capstone.skill_service.mapper.TrackMapper;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
@@ -17,11 +18,14 @@ import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +35,8 @@ public class TrackServiceImpl implements TrackService {
     private final CapsuleMapper capsuleMapper;
     private final TrackRepository trackRepository;
     private final TrackMapper trackMapper;
-
+    private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
+    private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
 
     @Override
     public TrackResponseDto create(TrackRequestDto dto) {
@@ -95,46 +100,138 @@ public class TrackServiceImpl implements TrackService {
 
     @Override
     public Optional<GrowthTrackEntity> findById(UUID id) {
-        return Optional.empty();
+        return this.trackRepository.findById(id);
     }
 
     @Override
+    @Cacheable("growthTrackList")
     public CustomPageResponse<TrackResponseDto> findAll(Pageable pageable) {
-        return null;
+        Page<GrowthTrackEntity> growthTrackList = this.trackRepository.findAllWithSkillCapsule(pageable);
+        Page<TrackResponseDto> growthTracks = growthTrackList.map(this.trackMapper::toDto);
+
+        logger.info("Growth tracks list is fetched");
+
+        return CustomPageResponse.<TrackResponseDto>builder()
+                .items(growthTracks.getContent())
+                .page(growthTracks.getNumber())
+                .size(growthTracks.getSize())
+                .totalElements(growthTracks.getTotalElements())
+                .totalPages(growthTracks.getTotalPages())
+                .hasNext(growthTracks.hasNext())
+                .hasPrevious(growthTracks.hasPrevious())
+                .build();
+    }
+
+    @Override
+    @Cacheable(value = "growthTrack", key = "#trackId")
+    public TrackWithCapsuleResponseDto getTrackWithCapsules(UUID trackId) {
+        GrowthTrackEntity track = trackRepository.findByIdWithCapsules(trackId)
+                .orElseThrow(() -> new TrackNotFoundException("A Growth Track not found"));
+
+        // get mappings (capsule and sequence order)
+        List<TrackCapsuleMappingEntity> mappings =
+                trackCapsuleMappingRepository.findByTrackIdsWithCapsules(trackId);
+
+        if (mappings.isEmpty()) {
+            TrackWithCapsuleResponseDto dto = trackMapper.toWithCapsuleDto(track);
+            dto.setCapsules(List.of()); // return empty list in capsule field
+            return dto;
+        }
+
+        // fetch capsules in growth track
+        List<SkillCapsuleEntity> capsules = mappings.stream().map(TrackCapsuleMappingEntity::getCapsule).toList();
+
+        // fetch capsule children (atoms and tags for all capsules)
+        List<UUID> capsuleIds = capsules.stream().map(SkillCapsuleEntity::getId).toList();
+        Map<UUID, List<AtomInSequenceOrderResponseDto>> atomsByCapsule = getAtomsByCapsule(capsuleIds);
+
+        // map capsules to ResponseDto
+        List<CapsuleInSequenceOrderResponseDto> capsuleResponse = mapResultToDto(mappings, atomsByCapsule);
+
+        // build the final dto response
+        TrackWithCapsuleResponseDto dto = trackMapper.toWithCapsuleDto(track);
+        dto.setCapsules(capsuleResponse);
+
+        return dto;
+    }
+
+
+    public Map<UUID, List<AtomInSequenceOrderResponseDto>> getAtomsByCapsule(List<UUID> capsuleIds){
+        List<CapsuleAtomMappingEntity> mappings = capsuleAtomMappingRepository.findByCapsuleIdsWithAtoms(capsuleIds);
+
+        // group atoms by capsule
+        return mappings.stream()
+                .collect(Collectors.groupingBy(
+                        m -> m.getCapsule().getId(),
+                        LinkedHashMap::new,
+                        Collectors.mapping(capsuleMapper::toAtomDto, Collectors.toList())
+                ));
+    }
+
+    public List<CapsuleInSequenceOrderResponseDto> mapResultToDto(List<TrackCapsuleMappingEntity> mappings ,
+                                                                  Map<UUID, List<AtomInSequenceOrderResponseDto>> atomsByCapsule){
+        return mappings.stream()
+                .map(mapping -> {
+                    SkillCapsuleEntity capsule = mapping.getCapsule();
+
+                    CapsuleInSequenceOrderResponseDto dto = capsuleMapper.toInSequenceOrderDto(mapping);
+                    dto.setSequenceOrder(mapping.getSequenceOrder()); // link the sequence order
+                    dto.setSkillAtoms(atomsByCapsule.getOrDefault(capsule.getId(), List.of()));
+
+                    return dto;
+                })
+                .toList();
     }
 
     @Override
     public TrackResponseDto getTrack(UUID id) {
-        return null;
+        GrowthTrackEntity track = findById(id)
+                .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
+                );
+
+        logger.info("Growth track {} retrieved", track.getName());
+
+        return this.trackMapper.toDto(track);
     }
 
     @Override
     public void deleteById(UUID id) {
+        GrowthTrackEntity track = findById(id)
+                .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
+                );
 
+        logger.info("Growth track {} deleted", track.getName());
+
+        this.capsuleRepository.deleteById(id);
     }
 
     @Override
     public TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id) {
+        //TODO
         return null;
     }
 
     @Override
     public TrackResponseDto updateStatus(Status status, UUID id) {
+        //TODO
         return null;
     }
 
     @Override
     public TrackResponseDto assignCapsuleToTrack(UUID trackId, CapsuleIdsRequestDto dto) {
+        //TODO
         return null;
     }
 
     @Override
     public TrackResponseDto removeCapsuleFromTrack(UUID trackId, UUID capsuleId) {
+        //TODO
         return null;
     }
 
     @Override
     public TrackResponseDto reorderCapsules(UUID trackId, List<UUID> orderedCapsuleIds) {
+        //TODO
         return null;
     }
 


### PR DESCRIPTION
# 🚀 Pull Request: Create a learning growth track

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Create a learning growth track](https://amali-tech.atlassian.net/browse/VER-96)

---

## ✅ Summary

This PR adds functionality for admins to create a growth track, assign capsules to a growth track, and fetch all the growth tracks to visualize the capsules that are in a particular growth track.

---

## 📌 Features Added

- [x] Growth track creation
- [x] Assigning capsules to a growth track
- [x] Retrieve growth track with its related capsules
- [x] Set capsule default sequence order when assigned to a growth track
- [x] Cache with Redis

---

## 🚧 Next Task

- Delete and update the growth track
- Manage capsule sequence order
- Remove the capsule from the growth track collection