### PR TITLE
Remove capsule from growth track and manage sequence order

### DIFF
--- a/src/main/java/com/capstone/skill_service/exception/GlobalException.java
+++ b/src/main/java/com/capstone/skill_service/exception/GlobalException.java
@@ -251,4 +251,17 @@ public class GlobalException {
                 .build();
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
+
+    @ExceptionHandler(InvalidCapsuleIdsException.class)
+    public ResponseEntity<?> handleInvalidCapsuleIdsException
+            (InvalidCapsuleIdsException exception) {
+
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Invalid skill capsule Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/capstone/skill_service/exception/InvalidCapsuleIdsException.java
+++ b/src/main/java/com/capstone/skill_service/exception/InvalidCapsuleIdsException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class InvalidCapsuleIdsException extends AppException{
+    public InvalidCapsuleIdsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -261,9 +261,21 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "trackList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "track", key = "#result.id") // Different cache name for individual track
+    )
     public TrackResponseDto assignCapsuleToTrack(UUID trackId, CapsuleIdsRequestDto dto) {
-        //TODO
-        return null;
+        GrowthTrackEntity track = findById(trackId)
+                .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
+                );
+
+        addCapsulesToTrack(track, dto.getCapsuleIds()); // link track to all the capsules assigned to it
+
+        logger.info("Admin added new skill capsule to growth track: {}", track.getName());
+
+        return this.trackMapper.toDto(trackRepository.save(track));
+
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -251,8 +251,13 @@ public class TrackServiceImpl implements TrackService {
 
     @Override
     public TrackResponseDto updateStatus(Status status, UUID id) {
-        //TODO
-        return null;
+        GrowthTrackEntity track = findById(id)
+                .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
+                );
+        track.setStatus(status);
+
+        return this.trackMapper.toDto(this.trackRepository.save(track));
+
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -18,7 +18,10 @@ import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -206,9 +209,44 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "trackList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "track", key = "#result.id") // Different cache name for individual track
+    )
     public TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id) {
-        //TODO
-        return null;
+        GrowthTrackEntity track = findById(id)
+                .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
+                );
+        if(dto.getName() != null){
+            if(findByName(dto.getName()).isPresent()){
+                throw new TrackNotFoundException(
+                        String.format("A Growth track with the name '%s' already exist",
+                                dto.getName()));
+            }
+            track.setName(dto.getName());
+        }
+        if(dto.getDescription() != null){
+            track.setDescription(dto.getDescription());
+        }
+        if(dto.getDescription() != null){
+            track.setDescription(dto.getDescription());
+        }
+
+        if(dto.getEstimatedMonths() != track.getEstimatedMonths()){
+            track.setEstimatedMonths(dto.getEstimatedMonths());
+        }
+        if(dto.getStatus() != null){
+            track.setStatus(dto.getStatus());
+        }
+        if(dto.getCapsuleIds() != null){
+            addCapsulesToTrack(track, dto.getCapsuleIds());
+        }
+
+        track.setUpdatedAt(LocalDateTime.now());
+
+        logger.info("Growth track {} updated", track.getName());
+
+        return this.trackMapper.toDto(this.trackRepository.save(track));
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -286,8 +286,33 @@ public class TrackServiceImpl implements TrackService {
 
     @Override
     public TrackResponseDto reorderCapsules(UUID trackId, List<UUID> orderedCapsuleIds) {
-        //TODO
-        return null;
+        GrowthTrackEntity trackEntity = findById(trackId)
+                .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
+                );
+
+        // check whether all the incoming capsules exist in track list in DB
+        List<TrackCapsuleMappingEntity> existingCapsules = trackEntity.getSkillCapsules(); // in database
+        List<UUID> existingCapsuleIds = existingCapsules.stream().map(m->m.getCapsule().getId()).toList();
+
+        Set<UUID> noneDuplicateOrderedCapsuleIds = new HashSet<>(orderedCapsuleIds);
+
+        if(! new HashSet<>(existingCapsuleIds).containsAll(orderedCapsuleIds) || noneDuplicateOrderedCapsuleIds.size() != orderedCapsuleIds.size()){
+            throw new InvalidCapsuleIdsException("Invalid skill capsule for this track");
+        }
+
+        // Update sequence order
+        for (int i = 0; i < orderedCapsuleIds.size(); i++) {
+            UUID capsuleId = orderedCapsuleIds.get(i); // incoming capsule
+
+            TrackCapsuleMappingEntity existingCapsuleMapping = existingCapsules.stream()
+                    .filter(m -> m.getCapsule().getId().equals(capsuleId))
+                    .findFirst()
+                    .orElseThrow(() -> new CapsuleNotFoundException("A skill capsule provided doesn't exist in track"));
+
+            existingCapsuleMapping.setSequenceOrder(i + 1); // update sequence order
+        }
+        return trackMapper.toDto(trackRepository.save(trackEntity));
+
     }
 
 }


### PR DESCRIPTION
# 🚀 Pull Request: Create a learning growth track

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Create a learning growth track](https://amali-tech.atlassian.net/browse/VER-96)

---

## ✅ Summary

This PR adds functionality for admins to update, delete, and remove capsules from the growth and to manage the sequence order of capsules in the growth track collection.

---

## 📌 Features Added

- [x] Growth track update and deletion
- [x] Removing capsule from a growth track
- [x] Manage sequence order
- [x] Update growth track status for soft delete

---

## 🚧 Next Task

- Create a learning route