### PR TITLE
Create a talent route and assign growth track to it.

### DIFF
--- a/src/main/java/com/capstone/skill_service/controller/RouteController.java
+++ b/src/main/java/com/capstone/skill_service/controller/RouteController.java
@@ -1,0 +1,157 @@
+package com.capstone.skill_service.controller;
+
+import com.capstone.skill_service.dto.ClientResponseFormatDto;
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.route.RouteRequestDto;
+import com.capstone.skill_service.dto.route.RouteResponseDto;
+import com.capstone.skill_service.dto.route.RouteUpdateRequestDto;
+import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
+import com.capstone.skill_service.dto.track.TrackIdsRequestDto;
+import com.capstone.skill_service.service.RouteService;
+import com.capstone.skill_service.util.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("talent-routes")
+@Tag(name = "Talent routes Controller", description = "Manage all talent route's api")
+public class RouteController {
+    private final RouteService routeService;
+
+    @PostMapping()
+    @Operation(summary = "Create talent route", description = "This end point allows only admin to create a talent route")
+    public ResponseEntity<ClientResponseFormatDto> createRoute(
+            @Valid @RequestBody RouteRequestDto routeRequestDto
+    ) {
+        RouteResponseDto savedRoute = this.routeService.create(routeRequestDto);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Route created successfully!")
+                .errors(null)
+                .data(savedRoute)
+                .build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping()
+    @Operation(summary = "Retrieve talent routes", description = "This end point allows only admin to fetch all talent routes")
+    public ResponseEntity<ClientResponseFormatDto> fetchAllRoutes(Pageable pageable) {
+        CustomPageResponse<RouteResponseDto> routes = this.routeService.findAll(pageable);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Fetch all talent routes")
+                .errors(null)
+                .data(routes)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/{routeId}")
+    @Operation(summary = "Retrieve talent routes", description = "This end point allows only admin to fetch all talent routes")
+    public ResponseEntity<ClientResponseFormatDto> retrieveSingleRoute(@PathVariable UUID routeId) {
+        RouteWithTrackResponseDto route = this.routeService.getRouteWithTracks(routeId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Route retrieved successfully")
+                .errors(null)
+                .data(route)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping(name = "delete_route", path = "/{id}")
+    @Operation(summary = "Delete Route",
+            description = "The route is deleted using its id that is passed as parameter")
+    public ResponseEntity<ClientResponseFormatDto> deleteRoute(@PathVariable UUID id){
+        this.routeService.deleteById(id);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Growth Route deleted successfully!")
+                .errors(null)
+                .data(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/{routeId}")
+    @Operation(summary = "Update talent route", description = "This end point allows admin to update a talent route")
+    public ResponseEntity<ClientResponseFormatDto> updateRoute(
+            @Valid @RequestBody RouteUpdateRequestDto routeRequestDto, @PathVariable UUID routeId) {
+        RouteResponseDto updatedRoute = this.routeService.partialUpdate(routeRequestDto, routeId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Growth Route updated successfully!")
+                .errors(null)
+                .data(updatedRoute)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PutMapping
+    @Operation(summary = "Update talent route status", description = "This end point allows admin to update a talent route as a soft delete")
+    public ResponseEntity<ClientResponseFormatDto> updateRouteStatus(
+            @RequestParam UUID id, @RequestParam Status status) {
+        RouteResponseDto updatedRoute = this.routeService.updateStatus(status, id);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Growth Route status updated successfully!")
+                .errors(null)
+                .data(updatedRoute)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/assignTrack/{routeId}")
+    @Operation(summary = "Assign new skill capsule to a talent route", description = "This end point allows admin to add new skill capsule to a talent route")
+    public ResponseEntity<ClientResponseFormatDto> assignTrackToRoute(
+            @RequestBody TrackIdsRequestDto atomIds, @PathVariable UUID routeId) {
+        RouteResponseDto updatedRoute = this.routeService.assignTrackToRoute(routeId, atomIds);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Tracks added to a talent route successfully!")
+                .errors(null)
+                .data(updatedRoute)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping("/removeTrack")
+    @Operation(summary = "Remove a growth atom from route", description = "This end point allows admin to remove a growth atom from route")
+    public ResponseEntity<ClientResponseFormatDto> removeTrackFromRoute(
+            @RequestParam UUID routeId, @RequestParam UUID atomId) {
+        RouteResponseDto updatedRoute = this.routeService.removeTrackFromRoute(routeId, atomId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Track removed from route successfully!")
+                .errors(null)
+                .data(updatedRoute)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PutMapping("/reorderTrack/{routeId}")
+    @Operation(summary = "Reorder new skill capsule in a talent route collection", description = "This end point allows admin " +
+            "to shift capsule sequence order in a talent route however they want")
+    public ResponseEntity<ClientResponseFormatDto> reorderTrack(
+            @RequestBody TrackIdsRequestDto atomIds, @PathVariable UUID routeId) {
+        RouteResponseDto updatedRoute = this.routeService.reorderTracks(routeId, atomIds.getTrackIds());
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(true)
+                .message("Tracks reordered in route successfully!")
+                .errors(null)
+                .data(updatedRoute)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+}

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteRequestDto.java
@@ -1,0 +1,34 @@
+package com.capstone.skill_service.dto.route;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RouteRequestDto {
+    @NotBlank(message = "Name is required")
+    @Size(min = 3, message = "Name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    private String name;
+
+    @NotBlank(message = "Role name is required")
+    @Size(min = 3, message = "Role name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "Role name cannot contain numbers")
+    private String roleName;
+
+    List<UUID> trackIds; // list of growth track ids
+    private String description;
+    private Status status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteResponseDto.java
@@ -1,6 +1,7 @@
 package com.capstone.skill_service.dto.route;
 
 import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
+import com.capstone.skill_service.dto.track.TrackSummaryResponseDto;
 import com.capstone.skill_service.util.Status;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
@@ -27,7 +28,7 @@ public class RouteResponseDto implements Serializable {
     private String roleName;
     private String description;
     private Status status;
-    private List<CapsuleSummaryResponseDto> tracks;
+    private List<TrackSummaryResponseDto> tracks;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteResponseDto.java
@@ -1,0 +1,33 @@
+package com.capstone.skill_service.dto.route;
+
+import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
+import com.capstone.skill_service.util.Status;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+public class RouteResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private String roleName;
+    private String description;
+    private Status status;
+    private List<CapsuleSummaryResponseDto> tracks;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteUpdateRequestDto.java
@@ -1,0 +1,34 @@
+package com.capstone.skill_service.dto.route;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RouteUpdateRequestDto {
+    @Size(min = 3, message = "Name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
+    private String name;
+
+    @NotBlank(message = "Role name is required")
+    @Size(min = 3, message = "Role name must have at least 3 characters")
+    @Pattern(regexp = "^[A-Za-z ]+$", message = "Role name cannot contain numbers")
+    private String roleName;
+
+    List<UUID> growthIds; // list of growth track ids
+    private String description;
+    private Status status;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteWithTrackResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteWithTrackResponseDto.java
@@ -1,0 +1,32 @@
+package com.capstone.skill_service.dto.route;
+
+import com.capstone.skill_service.dto.track.TrackInSequenceOrderResponseDto;
+import com.capstone.skill_service.util.Status;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+public class RouteWithTrackResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private String roleName;
+    private String description;
+    private Status status;
+    private List<TrackInSequenceOrderResponseDto> tracks;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackIdsRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackIdsRequestDto.java
@@ -1,0 +1,18 @@
+package com.capstone.skill_service.dto.track;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrackIdsRequestDto {
+    private List<UUID> trackIds;
+}

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackInSequenceOrderResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackInSequenceOrderResponseDto.java
@@ -1,0 +1,29 @@
+package com.capstone.skill_service.dto.track;
+
+import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
+import com.capstone.skill_service.util.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrackInSequenceOrderResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private String description;
+    private int estimatedMonths;
+    private Status status;
+    private List<CapsuleInSequenceOrderResponseDto> capsules;
+    private int sequenceOrder;
+}

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackSummaryResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackSummaryResponseDto.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public class TrackSummaryResponseDto implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackSummaryResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackSummaryResponseDto.java
@@ -1,0 +1,26 @@
+package com.capstone.skill_service.dto.track;
+
+import com.capstone.skill_service.util.Status;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+public class TrackSummaryResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private UUID id;
+    private String name;
+    private int estimatedMonths;
+    private Status status;
+}

--- a/src/main/java/com/capstone/skill_service/exception/GlobalException.java
+++ b/src/main/java/com/capstone/skill_service/exception/GlobalException.java
@@ -252,6 +252,32 @@ public class GlobalException {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(RouteExistsException.class)
+    public ResponseEntity<?> handleRouteExists
+            (RouteExistsException exception) {
+
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Talent Route Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(RouteNotFoundException.class)
+    public ResponseEntity<?> handleRouteNotFound(
+            RouteNotFoundException exception) {
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Talent Route Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(InvalidCapsuleIdsException.class)
     public ResponseEntity<?> handleInvalidCapsuleIdsException
             (InvalidCapsuleIdsException exception) {

--- a/src/main/java/com/capstone/skill_service/exception/RouteExistsException.java
+++ b/src/main/java/com/capstone/skill_service/exception/RouteExistsException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class RouteExistsException extends AppException{
+    public RouteExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/exception/RouteNotFoundException.java
+++ b/src/main/java/com/capstone/skill_service/exception/RouteNotFoundException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class RouteNotFoundException extends AppException{
+    public RouteNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
@@ -1,17 +1,11 @@
 package com.capstone.skill_service.mapper;
 
-import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
 import com.capstone.skill_service.dto.route.RouteRequestDto;
 import com.capstone.skill_service.dto.route.RouteResponseDto;
 import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
-import com.capstone.skill_service.dto.track.TrackRequestDto;
-import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.dto.track.TrackSummaryResponseDto;
-import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
-import com.capstone.skill_service.model.GrowthTrackEntity;
 import com.capstone.skill_service.model.RouteTrackMappingEntity;
 import com.capstone.skill_service.model.TalentRouteEntity;
-import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 

--- a/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
@@ -1,0 +1,33 @@
+package com.capstone.skill_service.mapper;
+
+import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
+import com.capstone.skill_service.dto.route.RouteRequestDto;
+import com.capstone.skill_service.dto.route.RouteResponseDto;
+import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
+import com.capstone.skill_service.dto.track.TrackRequestDto;
+import com.capstone.skill_service.dto.track.TrackResponseDto;
+import com.capstone.skill_service.dto.track.TrackSummaryResponseDto;
+import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
+import com.capstone.skill_service.model.GrowthTrackEntity;
+import com.capstone.skill_service.model.RouteTrackMappingEntity;
+import com.capstone.skill_service.model.TalentRouteEntity;
+import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface RouteMapper {
+    @Mapping(target = "tracks", source = "tracks")
+    RouteResponseDto toDto(TalentRouteEntity entity);
+
+    TalentRouteEntity toEntity(RouteRequestDto dto);
+    @Mapping(target = "tracks",  ignore = true)
+    RouteWithTrackResponseDto toWithTrackDto(TalentRouteEntity entity);
+
+    @Mapping(target = "id", source = "growthTrack.id")
+    @Mapping(target = "name", source = "growthTrack.name")
+    @Mapping(target = "status", source = "growthTrack.status")
+    @Mapping(target = "estimatedMonths", source = "growthTrack.estimatedMonths")
+    TrackSummaryResponseDto mapToTrackDto(RouteTrackMappingEntity mapping);
+
+}

--- a/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
@@ -1,10 +1,12 @@
 package com.capstone.skill_service.mapper;
 
 import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
+import com.capstone.skill_service.dto.track.TrackInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.track.TrackRequestDto;
 import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.dto.track.TrackWithCapsuleResponseDto;
 import com.capstone.skill_service.model.GrowthTrackEntity;
+import com.capstone.skill_service.model.RouteTrackMappingEntity;
 import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -23,5 +25,14 @@ public interface TrackMapper {
     @Mapping(target = "difficulty", source = "capsule.difficulty")
     @Mapping(target = "proficiencyLevel", source = "capsule.proficiencyLevel")
     CapsuleSummaryResponseDto mapToCapsuleDto(TrackCapsuleMappingEntity mapping);
+
+    @Mapping(target = "id", source = "growthTrack.id")
+    @Mapping(target = "name", source = "growthTrack.name")
+    @Mapping(target = "estimatedMonths", source = "growthTrack.estimatedMonths")
+    @Mapping(target = "status", source = "growthTrack.status")
+    @Mapping(target = "description", source = "growthTrack.description")
+    @Mapping(target = "capsules", source = "growthTrack.skillCapsules")
+    @Mapping(target = "sequenceOrder", source = "sequenceOrder")
+    TrackInSequenceOrderResponseDto toInSequenceOrderDto(RouteTrackMappingEntity mapping);
 
 }

--- a/src/main/java/com/capstone/skill_service/model/RouteTrackMappingEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/RouteTrackMappingEntity.java
@@ -1,0 +1,33 @@
+package com.capstone.skill_service.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "route_tracks")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RouteTrackMappingEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "talent_route_id")
+    private TalentRouteEntity talentRoute;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "growth_track_id")
+    private GrowthTrackEntity growthTrack;
+
+    @Column(nullable = false)
+    private Integer sequenceOrder;
+
+}

--- a/src/main/java/com/capstone/skill_service/model/TalentRouteEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/TalentRouteEntity.java
@@ -1,0 +1,44 @@
+package com.capstone.skill_service.model;
+
+import com.capstone.skill_service.util.Status;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "talent_routes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TalentRouteEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String roleName;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @OneToMany(mappedBy = "talentRoute", cascade = CascadeType.ALL, orphanRemoval = true) // just remove child from talent route list
+    @OrderBy("sequenceOrder ASC") // to always display growth track in sequence order
+    private List<RouteTrackMappingEntity> tracks = new ArrayList<>();
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/skill_service/repository/RouteRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/RouteRepository.java
@@ -1,0 +1,34 @@
+package com.capstone.skill_service.repository;
+
+import com.capstone.skill_service.model.GrowthTrackEntity;
+import com.capstone.skill_service.model.TalentRouteEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface RouteRepository extends JpaRepository<TalentRouteEntity, UUID> {
+    Optional<TalentRouteEntity> findByName(String name);
+    Optional<TalentRouteEntity> findByRoleName(String roleName);
+
+    @Query("""
+        SELECT tr
+        FROM TalentRouteEntity tr
+        LEFT JOIN FETCH tr.tracks gt
+        where tr.id = :id
+    """)
+    Optional<TalentRouteEntity> findByIdWithGrowthTracks(@Param("id") UUID id);
+
+    @Query("""
+        SELECT tr FROM TalentRouteEntity tr
+        LEFT JOIN FETCH tr.tracks c
+        ORDER BY tr.createdAt DESC
+    """)
+    Page<TalentRouteEntity> findAllWithGrowthTrack(Pageable pageable);
+}

--- a/src/main/java/com/capstone/skill_service/repository/RouteTrackMappingRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/RouteTrackMappingRepository.java
@@ -1,0 +1,23 @@
+package com.capstone.skill_service.repository;
+
+import com.capstone.skill_service.model.RouteTrackMappingEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface RouteTrackMappingRepository extends JpaRepository<RouteTrackMappingEntity, UUID> {
+    @Query("""
+    SELECT rt
+    FROM RouteTrackMappingEntity rt
+    JOIN FETCH rt.growthTrack
+    WHERE rt.talentRoute.id = :trackId
+    ORDER BY rt.talentRoute.id, rt.sequenceOrder
+""")
+    List<RouteTrackMappingEntity> findByTrackIdsWithCapsules(@Param("trackId") UUID trackId);
+
+}

--- a/src/main/java/com/capstone/skill_service/service/RouteService.java
+++ b/src/main/java/com/capstone/skill_service/service/RouteService.java
@@ -1,8 +1,10 @@
 package com.capstone.skill_service.service;
 
 import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.route.RouteRequestDto;
 import com.capstone.skill_service.dto.route.RouteResponseDto;
 import com.capstone.skill_service.dto.route.RouteUpdateRequestDto;
+import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
 import com.capstone.skill_service.dto.track.*;
 import com.capstone.skill_service.model.TalentRouteEntity;
 import com.capstone.skill_service.util.Status;

--- a/src/main/java/com/capstone/skill_service/service/RouteService.java
+++ b/src/main/java/com/capstone/skill_service/service/RouteService.java
@@ -1,0 +1,30 @@
+package com.capstone.skill_service.service;
+
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.route.RouteResponseDto;
+import com.capstone.skill_service.dto.route.RouteUpdateRequestDto;
+import com.capstone.skill_service.dto.track.*;
+import com.capstone.skill_service.model.TalentRouteEntity;
+import com.capstone.skill_service.util.Status;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RouteService {
+    RouteResponseDto create(RouteRequestDto dto);
+    Optional<TalentRouteEntity> findByName(String name);
+    Optional<TalentRouteEntity> findByRoleName(String roleName);
+    Optional<TalentRouteEntity> findById(UUID id);
+    CustomPageResponse<RouteResponseDto> findAll(Pageable pageable);
+    RouteResponseDto getRoute(UUID id);
+    RouteWithTrackResponseDto getRouteWithTracks(UUID routeId);
+    void deleteById(UUID id);
+    RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, UUID id);
+    RouteResponseDto updateStatus(Status status, UUID id);
+    RouteResponseDto assignTrackToRoute(UUID routeId, TrackIdsRequestDto dto);
+    RouteResponseDto removeTrackFromRoute(UUID routeId, UUID trackId);
+    RouteResponseDto reorderTracks(UUID routeId, List<UUID> orderedTrackIds);
+
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -1,0 +1,158 @@
+package com.capstone.skill_service.service.impl;
+
+import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.route.RouteRequestDto;
+import com.capstone.skill_service.dto.route.RouteResponseDto;
+import com.capstone.skill_service.dto.route.RouteUpdateRequestDto;
+import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
+import com.capstone.skill_service.dto.track.*;
+import com.capstone.skill_service.exception.*;
+import com.capstone.skill_service.mapper.CapsuleMapper;
+import com.capstone.skill_service.mapper.RouteMapper;
+import com.capstone.skill_service.mapper.TrackMapper;
+import com.capstone.skill_service.model.*;
+import com.capstone.skill_service.repository.*;
+import com.capstone.skill_service.service.RouteService;
+import com.capstone.skill_service.util.Status;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class RouteServiceImpl implements RouteService {
+    private static final Logger logger = LoggerFactory.getLogger(RouteServiceImpl.class);
+    private final CapsuleRepository capsuleRepository;
+    private final CapsuleMapper capsuleMapper;
+    private final TrackRepository trackRepository;
+    private final RouteRepository routeRepository;
+    private final RouteMapper routeMapper;
+    private final TrackMapper trackMapper;
+    private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
+    private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
+
+
+    @Override
+    public RouteResponseDto create(RouteRequestDto dto) {
+        if(findByName(dto.getName()).isPresent()){
+            throw new RouteExistsException(
+                    String.format("A talent route with the name '%s' already exist",
+                            dto.getName()));
+        }
+        if(findByRoleName(dto.getRoleName()).isPresent()){
+            throw new RouteExistsException(
+                    String.format("A role name '%s' already exist",
+                            dto.getRoleName()));
+        }
+        TalentRouteEntity routeEntity = this.routeMapper.toEntity(dto);
+
+        routeEntity.setCreatedAt(LocalDateTime.now());
+        routeEntity.setUpdatedAt(LocalDateTime.now());
+        routeEntity.setStatus(Status.ACTIVE);
+        addTrackToRoute(routeEntity, dto.getTrackIds()); // link talent route to all the talent route assigned to
+
+
+        logger.info("Admin created skill track: {}", routeEntity.getName());
+
+        return this.routeMapper.toDto(routeRepository.save(routeEntity));
+
+    }
+
+    void addTrackToRoute(TalentRouteEntity routeEntity, List<UUID> trackIds){
+        if (routeEntity.getTracks() == null) {
+            routeEntity.setTracks(new ArrayList<>());
+        }
+
+        int numberOfTracksInRoute = routeEntity.getTracks().size();
+
+        for(int i=0; i<trackIds.size(); i++){
+            UUID trackId=trackIds.get(i); //get track id
+
+            GrowthTrackEntity track = this.trackRepository.findById(trackId)
+                    .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
+                    );
+
+            boolean alreadyAssignedToTrack = routeEntity.getTracks().stream()
+                    .anyMatch(mapping -> mapping.getGrowthTrack().getId().equals(trackId));
+
+            if(alreadyAssignedToTrack){
+                throw new AlreadyAssignedException("Growth track is already assigned to this talent route");
+            }
+
+            // assign growth track to a talent route
+            RouteTrackMappingEntity assignTrackToRoute = RouteTrackMappingEntity.builder()
+                    .growthTrack(track)
+                    .talentRoute(routeEntity)
+                    .sequenceOrder(numberOfTracksInRoute + i + 1) // set default sequence order, when child size is 0, order starts from 1 else starts from size number + 1
+                    .build();
+
+            routeEntity.getTracks().add(assignTrackToRoute);// add a single capsule to talent route collection
+        }
+
+    }
+
+    @Override
+    public Optional<TalentRouteEntity> findByName(String name) {
+        return this.routeRepository.findByName(name);
+    }
+
+    @Override
+    public Optional<TalentRouteEntity> findByRoleName(String roleName) {
+        return this.routeRepository.findByRoleName(roleName);
+    }
+
+    @Override
+    public Optional<TalentRouteEntity> findById(UUID id) {
+        return Optional.empty();
+    }
+
+    @Override
+    public CustomPageResponse<RouteResponseDto> findAll(Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public RouteResponseDto getRoute(UUID id) {
+        return null;
+    }
+
+    @Override
+    public RouteWithTrackResponseDto getRouteWithTracks(UUID routeId) {
+        return null;
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+
+    }
+
+    @Override
+    public RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, UUID id) {
+        return null;
+    }
+
+    @Override
+    public RouteResponseDto updateStatus(Status status, UUID id) {
+        return null;
+    }
+
+    @Override
+    public RouteResponseDto assignTrackToRoute(UUID routeId, TrackIdsRequestDto dto) {
+        return null;
+    }
+
+    @Override
+    public RouteResponseDto removeTrackFromRoute(UUID routeId, UUID trackId) {
+        return null;
+    }
+
+    @Override
+    public RouteResponseDto reorderTracks(UUID routeId, List<UUID> orderedTrackIds) {
+        return null;
+    }
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -68,7 +68,7 @@ public class TrackServiceImpl implements TrackService {
             trackEntity.setSkillCapsules(new ArrayList<>());
         }
 
-        int numberOfCapsulesInCapsule = trackEntity.getSkillCapsules().size();
+        int numberOfCapsulesInTrack = trackEntity.getSkillCapsules().size();
 
         for(int i=0; i<capsuleIds.size(); i++){
             UUID capsuleId=capsuleIds.get(i); //get capsule id
@@ -85,13 +85,13 @@ public class TrackServiceImpl implements TrackService {
             }
 
             // assign capsule to track
-            TrackCapsuleMappingEntity assignCapsuleToCapsule = TrackCapsuleMappingEntity.builder()
+            TrackCapsuleMappingEntity assignCapsuleToTrack = TrackCapsuleMappingEntity.builder()
                     .capsule(capsule)
                     .growthTrack(trackEntity)
-                    .sequenceOrder(numberOfCapsulesInCapsule + i + 1) // set default sequence order, when child size is 0, order starts from 1 else starts from size number + 1
+                    .sequenceOrder(numberOfCapsulesInTrack + i + 1) // set default sequence order, when child size is 0, order starts from 1 else starts from size number + 1
                     .build();
 
-            trackEntity.getSkillCapsules().add(assignCapsuleToCapsule);// add a single assignment to assigment collection
+            trackEntity.getSkillCapsules().add(assignCapsuleToTrack);// add a single capsule to growth track collection
         }
 
     }


### PR DESCRIPTION
# 🚀 Pull Request: Create a talent route

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Implement a learning route for a particular growth track.](https://amali-tech.atlassian.net/browse/VER-102)

---

## ✅ Summary

This PR adds functionality for admins to create a talent route and assign different growth tracks to it.

---

## 📌 Features Added

- [x] Growth track creation
- [x] Assigning growth track to a talent route
- [x] Set a default sequence order while assigning growth track 

---

## 🚧 Next Task

- Delete and update the talent route
- Update sequence order
- Remove the growth track from the talent route collection