### PR TITLE
Manage growth track sequence order in talent route

### DIFF
--- a/src/main/java/com/capstone/skill_service/controller/RouteController.java
+++ b/src/main/java/com/capstone/skill_service/controller/RouteController.java
@@ -126,10 +126,10 @@ public class RouteController {
     }
 
     @DeleteMapping("/removeTrack")
-    @Operation(summary = "Remove a growth atom from route", description = "This end point allows admin to remove a growth atom from route")
+    @Operation(summary = "Remove a growth track from route", description = "This end point allows admin to remove a growth track from route")
     public ResponseEntity<ClientResponseFormatDto> removeTrackFromRoute(
-            @RequestParam UUID routeId, @RequestParam UUID atomId) {
-        RouteResponseDto updatedRoute = this.routeService.removeTrackFromRoute(routeId, atomId);
+            @RequestParam UUID routeId, @RequestParam UUID trackId) {
+        RouteResponseDto updatedRoute = this.routeService.removeTrackFromRoute(routeId, trackId);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .status(true)
                 .message("Track removed from route successfully!")

--- a/src/main/java/com/capstone/skill_service/controller/TrackController.java
+++ b/src/main/java/com/capstone/skill_service/controller/TrackController.java
@@ -128,8 +128,8 @@ public class TrackController {
     @DeleteMapping("/removeCapsule")
     @Operation(summary = "Remove a growth atom from track", description = "This end point allows admin to remove a growth atom from track")
     public ResponseEntity<ClientResponseFormatDto> removeCapsuleFromTrack(
-            @RequestParam UUID trackId, @RequestParam UUID atomId) {
-        TrackResponseDto updatedTrack = this.trackService.removeCapsuleFromTrack(trackId, atomId);
+            @RequestParam UUID trackId, @RequestParam UUID capsuleId) {
+        TrackResponseDto updatedTrack = this.trackService.removeCapsuleFromTrack(trackId, capsuleId);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .status(true)
                 .message("Capsule removed from track successfully!")

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteUpdateRequestDto.java
@@ -22,12 +22,11 @@ public class RouteUpdateRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
 
-    @NotBlank(message = "Role name is required")
     @Size(min = 3, message = "Role name must have at least 3 characters")
     @Pattern(regexp = "^[A-Za-z ]+$", message = "Role name cannot contain numbers")
     private String roleName;
 
-    List<UUID> growthIds; // list of growth track ids
+    List<UUID> growthTrackIds; // list of growth track ids
     private String description;
     private Status status;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/capstone/skill_service/exception/GlobalException.java
+++ b/src/main/java/com/capstone/skill_service/exception/GlobalException.java
@@ -290,4 +290,17 @@ public class GlobalException {
                 .build();
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(InvalidTrackIdsException.class)
+    public ResponseEntity<?> handleInvalidTrackIdsException
+            (InvalidTrackIdsException exception) {
+
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message("Invalid growth track Error!")
+                .errors(List.of(Map.of("message", exception.getMessage())))
+                .data(null)
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/capstone/skill_service/exception/InvalidTrackIdsException.java
+++ b/src/main/java/com/capstone/skill_service/exception/InvalidTrackIdsException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class InvalidTrackIdsException extends AppException{
+    public InvalidTrackIdsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -297,8 +297,35 @@ public class RouteServiceImpl implements RouteService {
         return this.routeMapper.toDto(savedTrack);
     }
 
+
     @Override
-    public RouteResponseDto reorderTracks(UUID routeId, List<UUID> orderedTrackIds) {
-        return null;
+    public RouteResponseDto reorderTracks(UUID trackId, List<UUID> orderedTrackIds) {
+        TalentRouteEntity route = findById(trackId)
+                .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")
+                );
+
+        // check whether all the incoming growth tracks exist in talent route list in DB
+        List<RouteTrackMappingEntity> existingTracks = route.getTracks(); // in database
+        List<UUID> existingTrackIds = existingTracks.stream().map(m->m.getGrowthTrack().getId()).toList();
+
+        Set<UUID> noneDuplicateOrderedTrackIds = new HashSet<>(orderedTrackIds);
+
+        if(! new HashSet<>(existingTrackIds).containsAll(orderedTrackIds) || noneDuplicateOrderedTrackIds.size() != orderedTrackIds.size()){
+            throw new InvalidTrackIdsException("Invalid growth track for this talent route");
+        }
+
+        // Update sequence order
+        for (int i = 0; i < orderedTrackIds.size(); i++) {
+            UUID capsuleId = orderedTrackIds.get(i); // incoming capsule
+
+            RouteTrackMappingEntity existingTrackMapping = existingTracks.stream()
+                    .filter(m -> m.getGrowthTrack().getId().equals(capsuleId))
+                    .findFirst()
+                    .orElseThrow(() -> new TrackNotFoundException("A growth track provided doesn't exist in talent route"));
+
+            existingTrackMapping.setSequenceOrder(i + 1); // update sequence order
+        }
+        return routeMapper.toDto(routeRepository.save(route));
+
     }
 }

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -274,7 +274,27 @@ public class RouteServiceImpl implements RouteService {
 
     @Override
     public RouteResponseDto removeTrackFromRoute(UUID routeId, UUID trackId) {
-        return null;
+
+        TalentRouteEntity route = findById(routeId)
+                .orElseThrow(() -> new RouteNotFoundException("A talent route provided doesn't exist"));
+
+        // find the growth track to remove from talent route
+        RouteTrackMappingEntity growthTrackToRemove = route.getTracks().stream()
+                .filter(mapping -> mapping.getGrowthTrack().getId().equals(trackId))
+                .findFirst()
+                .orElseThrow(() -> new TrackNotFoundException("A growth track provided doesn't exist in talent route"));
+
+        route.getTracks().remove(growthTrackToRemove); // remove growth track from track collection
+
+        //Rearrange the sequence order
+        int order = 1;
+        for (RouteTrackMappingEntity mapping : route.getTracks()) {
+            mapping.setSequenceOrder(order++);
+        }
+        TalentRouteEntity savedTrack = routeRepository.save(route);
+
+        // map growth track to response dto
+        return this.routeMapper.toDto(savedTrack);
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -1,17 +1,13 @@
 package com.capstone.skill_service.service.impl;
 
 import com.capstone.skill_service.dto.CustomPageResponse;
-import com.capstone.skill_service.dto.atom.AtomInSequenceOrderResponseDto;
-import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.route.RouteRequestDto;
 import com.capstone.skill_service.dto.route.RouteResponseDto;
 import com.capstone.skill_service.dto.route.RouteUpdateRequestDto;
 import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
 import com.capstone.skill_service.dto.track.*;
 import com.capstone.skill_service.exception.*;
-import com.capstone.skill_service.mapper.CapsuleMapper;
 import com.capstone.skill_service.mapper.RouteMapper;
-import com.capstone.skill_service.mapper.TrackMapper;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
 import com.capstone.skill_service.service.RouteService;
@@ -251,7 +247,14 @@ public class RouteServiceImpl implements RouteService {
 
     @Override
     public RouteResponseDto updateStatus(Status status, UUID id) {
-        return null;
+
+        TalentRouteEntity route = findById(id)
+                .orElseThrow( () -> new RouteNotFoundException("A track route provided doesn't exist")
+                );
+        route.setStatus(status);
+
+        return this.routeMapper.toDto(this.routeRepository.save(route));
+
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -259,7 +259,17 @@ public class RouteServiceImpl implements RouteService {
 
     @Override
     public RouteResponseDto assignTrackToRoute(UUID routeId, TrackIdsRequestDto dto) {
-        return null;
+
+        TalentRouteEntity route = findById(routeId)
+                .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")
+                );
+
+        addTrackToRoute(route, dto.getTrackIds()); // link route to all the growth track assigned to it
+
+        logger.info("Admin added new growth track to talent route: {}", route.getName());
+
+        return this.routeMapper.toDto(routeRepository.save(route));
+
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -208,7 +208,45 @@ public class RouteServiceImpl implements RouteService {
 
     @Override
     public RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, UUID id) {
-        return null;
+        TalentRouteEntity route = findById(id)
+                .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")
+                );
+        if(dto.getName() != null){
+            if(findByName(dto.getName()).isPresent()){
+                throw new RouteNotFoundException(
+                        String.format("A talent route with the name '%s' already exist",
+                                dto.getName()));
+            }
+            route.setName(dto.getName());
+        }
+        if(dto.getRoleName() != null){
+            if(findByRoleName(dto.getRoleName()).isPresent()){
+                throw new RouteNotFoundException(
+                        String.format("A role with the name '%s' already exist",
+                                dto.getName()));
+            }
+            route.setName(dto.getName());
+        }
+        if(dto.getDescription() != null){
+            route.setDescription(dto.getDescription());
+        }
+        if(dto.getDescription() != null){
+            route.setDescription(dto.getDescription());
+        }
+
+        if(dto.getStatus() != null){
+            route.setStatus(dto.getStatus());
+        }
+        if(dto.getGrowthTrackIds() != null){
+            addTrackToRoute(route, dto.getGrowthTrackIds());
+        }
+
+        route.setUpdatedAt(LocalDateTime.now());
+
+        logger.info("Talent route {} updated", route.getName());
+
+        return this.routeMapper.toDto(this.routeRepository.save(route));
+
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -197,7 +197,13 @@ public class RouteServiceImpl implements RouteService {
 
     @Override
     public void deleteById(UUID id) {
+        TalentRouteEntity route = findById(id)
+                .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")
+                );
 
+        logger.info("Talent route {} deleted", route.getName());
+
+        this.routeRepository.deleteById(id);
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -6,6 +6,7 @@ import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.capsule.CapsuleWithDetailsResponseDto;
 import com.capstone.skill_service.dto.track.*;
 import com.capstone.skill_service.exception.*;
+import com.capstone.skill_service.mapper.CapsuleMapper;
 import com.capstone.skill_service.mapper.TrackMapper;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
@@ -33,6 +34,7 @@ public class TrackServiceImpl implements TrackService {
     private final CapsuleRepository capsuleRepository;
     private final TrackRepository trackRepository;
     private final TrackMapper trackMapper;
+    private final CapsuleMapper capsuleMapper;
     private final CapsuleService capsuleService;
     private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
 
@@ -263,8 +265,26 @@ public class TrackServiceImpl implements TrackService {
 
     @Override
     public TrackResponseDto removeCapsuleFromTrack(UUID trackId, UUID capsuleId) {
-        //TODO
-        return null;
+        GrowthTrackEntity trackEntity = findById(trackId)
+                .orElseThrow(() -> new TrackNotFoundException("A growth track provided doesn't exist"));
+
+        // find the capsule to remove from growth track
+        TrackCapsuleMappingEntity capsuleToRemove = trackEntity.getSkillCapsules().stream()
+                .filter(mapping -> mapping.getCapsule().getId().equals(capsuleId))
+                .findFirst()
+                .orElseThrow(() -> new CapsuleNotFoundException("A skill capsule provided doesn't exist in growth track"));
+
+        trackEntity.getSkillCapsules().remove(capsuleToRemove); // remove capsule from growth track collection
+
+        //Rearrange the sequence order
+        int order = 1;
+        for (TrackCapsuleMappingEntity mapping : trackEntity.getSkillCapsules()) {
+            mapping.setSequenceOrder(order++);
+        }
+        GrowthTrackEntity savedTrack = trackRepository.save(trackEntity);
+
+        // map growth track to response dto
+        return this.trackMapper.toDto(savedTrack);
     }
 
     @Override


### PR DESCRIPTION
# 🚀 Pull Request: Manage sequence order while updating and removing growth track

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Implement a learning route for a particular growth track.](https://amali-tech.atlassian.net/browse/VER-102)

---

## ✅ Summary

This PR adds functionality for admins to manage the sequence of a growth track in a talent route collection, as well as some additional functionalities, such as removing a growth track from a talent route and updating talent route information.

---

## 📌 Features Added

- [x] Talent route update and deletion
- [x] Assign new growth track to a talent route
- [x] Update sequence order of growth track

---

## 🚧 Next Task

- Cache request with more than three DB queries
- Double-check each fetching level(route, growth track and capsule) DB queries request and optimize it
- Upload capsule picture