### PR TITLE
Secure endpoint based on user Role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
+<!--      security-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/skill_service/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package com.capstone.skill_service.config;
+
+import com.capstone.skill_service.filter.UserContextFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final UserContextFilter userContextFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/actuator/health"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/dimensions").hasRole("MANAGER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/dimensions").hasRole("MANAGER")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/dimensions").hasRole("MANAGER")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/dimensions/**").hasAnyRole("MANAGER", "DEVELOPER")
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setContentType("application/json");
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.getWriter().write("{\"error\":\"Unauthorized\",\"message\":\"JWT token is missing or invalid\"}");
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setContentType("application/json");
+                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                            response.getWriter().write("{\"error\":\"Forbidden\",\"message\":\"You don't have permission to access this resource\"}");
+                        })
+                )
+                .addFilterBefore(userContextFilter, BasicAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+
+}

--- a/src/main/java/com/capstone/skill_service/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/SecurityConfig.java
@@ -32,10 +32,6 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/actuator/health"
                         ).permitAll()
-                        .requestMatchers(HttpMethod.PUT, "/api/v1/dimensions").hasRole("MANAGER")
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/dimensions").hasRole("MANAGER")
-                        .requestMatchers(HttpMethod.POST, "/api/v1/dimensions").hasRole("MANAGER")
-                        .requestMatchers(HttpMethod.GET, "/api/v1/dimensions/**").hasAnyRole("MANAGER", "DEVELOPER")
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex

--- a/src/main/java/com/capstone/skill_service/controller/AtomController.java
+++ b/src/main/java/com/capstone/skill_service/controller/AtomController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -27,6 +28,7 @@ public class AtomController {
     private final AtomService atomService;
 
     @PostMapping()
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create skill atom", description = "This end point allows only admin to create a skill atom")
     public ResponseEntity<ClientResponseFormatDto> createAtom(
             @Valid @RequestBody AtomRequestDto atomRequestDto
@@ -68,6 +70,7 @@ public class AtomController {
     }
 
     @DeleteMapping(name = "delete_atom", path = "/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete Atom",
             description = "The atom is delete using its id that is passed as parameter")
     public ResponseEntity<ClientResponseFormatDto> deleteAtom(@PathVariable UUID id){
@@ -83,6 +86,7 @@ public class AtomController {
     }
 
     @PatchMapping("/{atomId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update skill atom", description = "This end point allows admin to update a skill atom")
     public ResponseEntity<ClientResponseFormatDto> updateAtom(
             @Valid @RequestBody AtomUpdateRequestDto atomRequestDto, @PathVariable UUID atomId) {
@@ -97,6 +101,7 @@ public class AtomController {
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update skill atom status", description = "This end point allows admin to update a skill atom as a soft delete")
     public ResponseEntity<ClientResponseFormatDto> updateAtomStatus(
             @RequestParam UUID id, @RequestParam Status status) {

--- a/src/main/java/com/capstone/skill_service/controller/CapsuleController.java
+++ b/src/main/java/com/capstone/skill_service/controller/CapsuleController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -28,6 +29,7 @@ public class CapsuleController {
     private final CapsuleService capsuleService;
 
     @PostMapping()
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create skill capsule", description = "This end point allows only admin to create a skill capsule")
     public ResponseEntity<ClientResponseFormatDto> createCapsule(
             @Valid @RequestBody CapsuleRequestDto capsuleRequestDto
@@ -69,6 +71,7 @@ public class CapsuleController {
     }
 
     @DeleteMapping(name = "delete_capsule", path = "/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete Capsule",
             description = "The capsule is delete using its id that is passed as parameter")
     public ResponseEntity<ClientResponseFormatDto> deleteCapsule(@PathVariable UUID id){
@@ -84,6 +87,7 @@ public class CapsuleController {
     }
 
     @PatchMapping("/{capsuleId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update skill capsule", description = "This end point allows admin to update a skill capsule")
     public ResponseEntity<ClientResponseFormatDto> updateCapsule(
             @Valid @RequestBody CapsuleUpdateRequestDto capsuleRequestDto, @PathVariable UUID capsuleId) {
@@ -98,6 +102,7 @@ public class CapsuleController {
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update skill capsule status", description = "This end point allows admin to update a skill capsule as a soft delete")
     public ResponseEntity<ClientResponseFormatDto> updateCapsuleStatus(
             @RequestParam UUID id, @RequestParam Status status) {
@@ -112,6 +117,7 @@ public class CapsuleController {
     }
 
     @PatchMapping("/assignAtom/{capsuleId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Assign new skill atom to capsule", description = "This end point allows admin to add new skill atom to capsule")
     public ResponseEntity<ClientResponseFormatDto> assignAtomToCapsule(
             @RequestBody AtomIdsRequestDto atomIds, @PathVariable UUID capsuleId) {
@@ -126,6 +132,7 @@ public class CapsuleController {
     }
 
     @DeleteMapping("/removeAtom")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Remove a skill atom from capsule", description = "This end point allows admin to remove a skill atom from capsule")
     public ResponseEntity<ClientResponseFormatDto> removeAtomFromCapsule(
             @RequestParam UUID capsuleId, @RequestParam UUID atomId) {
@@ -140,6 +147,7 @@ public class CapsuleController {
     }
 
     @PutMapping("/reorderAtom/{capsuleId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Reorder new skill atom in capsule collection", description = "This end point allows admin " +
             "to shift atom sequence order in capsule however they want")
     public ResponseEntity<ClientResponseFormatDto> reorderAtom(
@@ -155,6 +163,7 @@ public class CapsuleController {
     }
 
     @PatchMapping("/assignTag/{capsuleId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Assign new skill tag to capsule", description = "This end point allows admin to add new skill tag to capsule")
     public ResponseEntity<ClientResponseFormatDto> assignTagToCapsule(
             @RequestBody TagIdsRequestDto tagIds, @PathVariable UUID capsuleId) {
@@ -169,6 +178,7 @@ public class CapsuleController {
     }
 
     @DeleteMapping("/removeTag")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Remove a skill tag from capsule", description = "This end point allows admin to remove a skill tag from capsule")
     public ResponseEntity<ClientResponseFormatDto> removeTagFromCapsule(
             @RequestParam UUID capsuleId, @RequestParam UUID tagId) {
@@ -183,6 +193,7 @@ public class CapsuleController {
     }
 
     @PatchMapping("/assignCluster/{capsuleId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Assign new skill cluster to capsule", description = "This end point allows admin to add new skill cluster to capsule")
     public ResponseEntity<ClientResponseFormatDto> assignClusterToCapsule(
             @RequestBody ClusterIdsRequestDto clusterIds, @PathVariable UUID capsuleId) {
@@ -197,6 +208,7 @@ public class CapsuleController {
     }
 
     @DeleteMapping("/removeCluster")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Remove a skill cluster from capsule", description = "This end point allows admin to remove a skill cluster from capsule")
     public ResponseEntity<ClientResponseFormatDto> removeClusterFromCapsule(
             @RequestParam UUID capsuleId, @RequestParam UUID clusterId) {

--- a/src/main/java/com/capstone/skill_service/controller/ClusterController.java
+++ b/src/main/java/com/capstone/skill_service/controller/ClusterController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -30,6 +31,7 @@ public class ClusterController {
     private final ClusterService clusterService;
 
     @PostMapping()
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create skill cluster", description = "This end point allows only admin to create a skill cluster")
     public ResponseEntity<ClientResponseFormatDto> createCluster(
             @RequestParam("name") String name,
@@ -66,6 +68,7 @@ public class ClusterController {
     }
 
     @DeleteMapping(name = "delete_cluster", path = "/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete Cluster",
             description = "The cluster is delete using its id that is passed as parameter")
     public ResponseEntity<ClientResponseFormatDto> deleteCluster(@PathVariable UUID id){
@@ -81,6 +84,7 @@ public class ClusterController {
     }
 
     @PatchMapping("update")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update skill cluster", description = "This end point allows admin to update a skill cluster")
     public ResponseEntity<ClientResponseFormatDto> updateCluster(
             @RequestParam(value = "name", required = false) String name,
@@ -106,6 +110,7 @@ public class ClusterController {
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update skill cluster status", description = "This end point allows admin to update a skill cluster as a soft delete")
     public ResponseEntity<ClientResponseFormatDto> updateClusterStatus(
             @RequestParam UUID id, @RequestParam Status status) {

--- a/src/main/java/com/capstone/skill_service/controller/RouteController.java
+++ b/src/main/java/com/capstone/skill_service/controller/RouteController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -29,6 +30,7 @@ public class RouteController {
     private final RouteService routeService;
 
     @PostMapping()
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create talent route", description = "This end point allows only admin to create a talent route")
     public ResponseEntity<ClientResponseFormatDto> createRoute(
             @Valid @RequestBody RouteRequestDto routeRequestDto
@@ -70,6 +72,7 @@ public class RouteController {
     }
 
     @DeleteMapping(name = "delete_route", path = "/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete Route",
             description = "The route is deleted using its id that is passed as parameter")
     public ResponseEntity<ClientResponseFormatDto> deleteRoute(@PathVariable UUID id){
@@ -85,6 +88,7 @@ public class RouteController {
     }
 
     @PatchMapping("/{routeId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update talent route", description = "This end point allows admin to update a talent route")
     public ResponseEntity<ClientResponseFormatDto> updateRoute(
             @Valid @RequestBody RouteUpdateRequestDto routeRequestDto, @PathVariable UUID routeId) {
@@ -99,6 +103,7 @@ public class RouteController {
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update talent route status", description = "This end point allows admin to update a talent route as a soft delete")
     public ResponseEntity<ClientResponseFormatDto> updateRouteStatus(
             @RequestParam UUID id, @RequestParam Status status) {
@@ -113,6 +118,7 @@ public class RouteController {
     }
 
     @PatchMapping("/assignTrack/{routeId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Assign new skill capsule to a talent route", description = "This end point allows admin to add new skill capsule to a talent route")
     public ResponseEntity<ClientResponseFormatDto> assignTrackToRoute(
             @RequestBody TrackIdsRequestDto atomIds, @PathVariable UUID routeId) {
@@ -127,6 +133,7 @@ public class RouteController {
     }
 
     @DeleteMapping("/removeTrack")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Remove a growth track from route", description = "This end point allows admin to remove a growth track from route")
     public ResponseEntity<ClientResponseFormatDto> removeTrackFromRoute(
             @RequestParam UUID routeId, @RequestParam UUID trackId) {
@@ -141,6 +148,7 @@ public class RouteController {
     }
 
     @PutMapping("/reorderTrack/{routeId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Reorder new skill capsule in a talent route collection", description = "This end point allows admin " +
             "to shift capsule sequence order in a talent route however they want")
     public ResponseEntity<ClientResponseFormatDto> reorderTrack(

--- a/src/main/java/com/capstone/skill_service/controller/TagController.java
+++ b/src/main/java/com/capstone/skill_service/controller/TagController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -27,6 +28,7 @@ public class TagController {
     private final TagService tagService;
 
     @PostMapping()
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create skill tag", description = "This end point allows only admin to create a skill tag")
     public ResponseEntity<ClientResponseFormatDto> createTag(
             @Valid @RequestBody TagRequestDto tagRequestDto
@@ -68,6 +70,7 @@ public class TagController {
     }
 
     @DeleteMapping(name = "delete_tag", path = "/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete Tag",
             description = "The tag is delete using its id that is passed as parameter")
     public ResponseEntity<ClientResponseFormatDto> deleteTag(@PathVariable UUID id){

--- a/src/main/java/com/capstone/skill_service/controller/TrackController.java
+++ b/src/main/java/com/capstone/skill_service/controller/TrackController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -29,6 +30,7 @@ public class TrackController {
     private final TrackService trackService;
 
     @PostMapping()
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create growth track", description = "This end point allows only admin to create a growth track")
     public ResponseEntity<ClientResponseFormatDto> createTrack(
             @Valid @RequestBody TrackRequestDto trackRequestDto
@@ -70,6 +72,7 @@ public class TrackController {
     }
 
     @DeleteMapping(name = "delete_track", path = "/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete Track",
             description = "The track is deleted using its id that is passed as parameter")
     public ResponseEntity<ClientResponseFormatDto> deleteTrack(@PathVariable UUID id){
@@ -85,6 +88,7 @@ public class TrackController {
     }
 
     @PatchMapping("/{trackId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update growth track", description = "This end point allows admin to update a growth track")
     public ResponseEntity<ClientResponseFormatDto> updateTrack(
             @Valid @RequestBody TrackUpdateRequestDto trackRequestDto, @PathVariable UUID trackId) {
@@ -99,6 +103,7 @@ public class TrackController {
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update growth track status", description = "This end point allows admin to update a growth track as a soft delete")
     public ResponseEntity<ClientResponseFormatDto> updateTrackStatus(
             @RequestParam UUID id, @RequestParam Status status) {
@@ -113,6 +118,7 @@ public class TrackController {
     }
 
     @PatchMapping("/assignCapsule/{trackId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Assign new skill capsule to a growth track", description = "This end point allows admin to add new skill capsule to a growth track")
     public ResponseEntity<ClientResponseFormatDto> assignCapsuleToTrack(
             @RequestBody CapsuleIdsRequestDto atomIds, @PathVariable UUID trackId) {
@@ -127,6 +133,7 @@ public class TrackController {
     }
 
     @DeleteMapping("/removeCapsule")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Remove a growth atom from track", description = "This end point allows admin to remove a growth atom from track")
     public ResponseEntity<ClientResponseFormatDto> removeCapsuleFromTrack(
             @RequestParam UUID trackId, @RequestParam UUID capsuleId) {
@@ -141,6 +148,7 @@ public class TrackController {
     }
 
     @PutMapping("/reorderCapsule/{trackId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Reorder new skill capsule in a growth track collection", description = "This end point allows admin " +
             "to shift capsule sequence order in a growth track however they want")
     public ResponseEntity<ClientResponseFormatDto> reorderCapsule(

--- a/src/main/java/com/capstone/skill_service/exception/GlobalException.java
+++ b/src/main/java/com/capstone/skill_service/exception/GlobalException.java
@@ -316,4 +316,16 @@ public class GlobalException {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(response);
     }
+
+    @ExceptionHandler(HeaderException.class)
+    public ResponseEntity<?> handleHeaderException(HeaderException exception) {
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .status(false)
+                .message(exception.getMessage())
+                .errors(null)
+                .data(null)
+                .build();
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(response);
+    }
 }

--- a/src/main/java/com/capstone/skill_service/exception/HeaderException.java
+++ b/src/main/java/com/capstone/skill_service/exception/HeaderException.java
@@ -1,0 +1,7 @@
+package com.capstone.skill_service.exception;
+
+public class HeaderException extends AppException{
+    public HeaderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/filter/UserContextFilter.java
+++ b/src/main/java/com/capstone/skill_service/filter/UserContextFilter.java
@@ -1,0 +1,62 @@
+package com.capstone.skill_service.filter;
+
+import com.capstone.skill_service.exception.HeaderException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class UserContextFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // fetch  user info from header
+        String userId = request.getHeader("X-User-Id");
+        String userEmail = request.getHeader("X-User-Email");
+        String userRoles = request.getHeader("X-User-Role");
+
+        log.info("Extracted headers - UserId: {}, UserEmail: {}, UserRoles: {}",
+                userId, userEmail, userRoles);
+
+        if (userId != null && !userId.trim().isEmpty() &&
+                userRoles != null && !userRoles.trim().isEmpty()) {
+
+            List<SimpleGrantedAuthority> authorities = Arrays.stream(userRoles.split(","))
+                    .map(String::trim)
+                    .filter(role -> !role.isEmpty())
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("User authenticated successfully: {} with roles: {}", userId, authorities);
+        } else {
+            log.warn("Authentication failed - Missing or empty userId ({}) or userRoles ({})", userId, userRoles);
+            throw new HeaderException("Authentication failed!");
+        }
+
+        filterChain.doFilter(request, response);
+        log.info("UserContextFilter completed for path: {}", request.getRequestURI());
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request: Secure endpoint for admin only 

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Skill taxonomy management.](https://amali-tech.atlassian.net/browse/VER-19)

---

## ✅ Summary

This PR restricts some endpoints for admin only, such as creating, updating, and deleting taxonomy. 

---

## 📌 Feature

- [x] Apply role-based access control 

---

## 🚧 Next Task

- Double-check each fetching level(talent route and growth track) DB queries request and optimize it