### PR TITLE
Safe deletion for associated entities

### DIFF
--- a/src/main/java/com/capstone/skill_service/controller/ClusterController.java
+++ b/src/main/java/com/capstone/skill_service/controller/ClusterController.java
@@ -11,6 +11,7 @@ import com.capstone.skill_service.service.ClusterService;
 import com.capstone.skill_service.util.Status;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -34,17 +35,9 @@ public class ClusterController {
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create skill cluster", description = "This end point allows only admin to create a skill cluster")
     public ResponseEntity<ClientResponseFormatDto> createCluster(
-            @RequestParam("name") String name,
-            @RequestParam("type") String type,
-            @RequestParam("description") String description,
-            @RequestParam(value = "image", required = false) MultipartFile image
-    )throws IOException {
-        ClusterRequestDto clusterRequestDto = ClusterRequestDto.builder()
-                .name(name)
-                .type(type)
-                .description(description)
-                .build();
-        ClusterResponseDto savedCluster = this.clusterService.create(clusterRequestDto, image);
+            @Valid @RequestBody ClusterRequestDto clusterRequestDto
+            ) {
+        ClusterResponseDto savedCluster = this.clusterService.create(clusterRequestDto, null);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .status(true)
                 .message("Cluster created successfully!")

--- a/src/main/java/com/capstone/skill_service/model/ClusterEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/ClusterEntity.java
@@ -42,6 +42,14 @@ public class ClusterEntity {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    // remove cluster first from mapping entity before deleting actual cluster
+    @PreRemove
+    private void removeAssociations() {
+        for (SkillCapsuleEntity capsule : capsules) {
+            capsule.getClusters().remove(this);
+        }
+    }
+
     //compare using id
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/capstone/skill_service/model/SkillAtomEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/SkillAtomEntity.java
@@ -33,6 +33,8 @@ public class SkillAtomEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    private String type;
+
     private int moodleSectionId; // id from moodle database on section table
     private int estimatedHours;
     private LocalDateTime createdAt;

--- a/src/main/java/com/capstone/skill_service/model/TagEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/TagEntity.java
@@ -40,6 +40,14 @@ public class TagEntity {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    // remove tag first from mapping entity before deleting actual tag
+    @PreRemove
+    private void removeAssociations() {
+        for (SkillCapsuleEntity capsule : capsules) {
+            capsule.getTags().remove(this);
+        }
+    }
+
     //compare using id
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/capstone/skill_service/repository/CapsuleAtomMappingRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/CapsuleAtomMappingRepository.java
@@ -29,5 +29,13 @@ public interface CapsuleAtomMappingRepository extends JpaRepository<CapsuleAtomM
     ORDER BY cam.sequenceOrder
 """)
     List<CapsuleAtomMappingEntity> findByCapsuleIdWithAtoms(@Param("capsuleId") UUID capsuleId);
+    @Query("""
+    SELECT cam
+    FROM CapsuleAtomMappingEntity cam
+    JOIN FETCH cam.atom
+    WHERE cam.atom.id = :atomId
+    ORDER BY cam.sequenceOrder
+""")
+    List<CapsuleAtomMappingEntity> findBySkillAtomId(@Param("atomId") UUID capsuleId);
 
 }

--- a/src/main/java/com/capstone/skill_service/repository/RouteTrackMappingRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/RouteTrackMappingRepository.java
@@ -1,6 +1,7 @@
 package com.capstone.skill_service.repository;
 
 import com.capstone.skill_service.model.RouteTrackMappingEntity;
+import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,5 +20,14 @@ public interface RouteTrackMappingRepository extends JpaRepository<RouteTrackMap
     ORDER BY rt.talentRoute.id, rt.sequenceOrder
 """)
     List<RouteTrackMappingEntity> findByTrackIdsWithCapsules(@Param("trackId") UUID trackId);
+
+    @Query("""
+    SELECT rt
+    FROM RouteTrackMappingEntity rt
+    JOIN FETCH rt.growthTrack
+    WHERE rt.growthTrack = :trackId
+    ORDER BY rt.sequenceOrder
+""")
+    List<RouteTrackMappingEntity> findByTrackId(@Param("trackId") UUID trackId);
 
 }

--- a/src/main/java/com/capstone/skill_service/repository/TrackCapsuleMappingRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackCapsuleMappingRepository.java
@@ -20,4 +20,13 @@ public interface TrackCapsuleMappingRepository extends JpaRepository<TrackCapsul
 """)
     List<TrackCapsuleMappingEntity> findByTrackIdsWithCapsules(@Param("trackId") UUID trackId);
 
+    @Query("""
+    SELECT tc
+    FROM TrackCapsuleMappingEntity tc
+    JOIN FETCH tc.capsule
+    WHERE tc.capsule = :capsuleId
+    ORDER BY tc.sequenceOrder
+""")
+    List<TrackCapsuleMappingEntity> findBySkillCapsuleId(@Param("capsuleId") UUID capsuleId);
+
 }

--- a/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
@@ -7,8 +7,10 @@ import com.capstone.skill_service.dto.atom.AtomUpdateRequestDto;
 import com.capstone.skill_service.exception.AtomExistsException;
 import com.capstone.skill_service.exception.AtomNotFoundException;
 import com.capstone.skill_service.mapper.AtomMapper;
+import com.capstone.skill_service.model.CapsuleAtomMappingEntity;
 import com.capstone.skill_service.model.SkillAtomEntity;
 import com.capstone.skill_service.repository.AtomRepository;
+import com.capstone.skill_service.repository.CapsuleAtomMappingRepository;
 import com.capstone.skill_service.service.AtomService;
 import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,6 +35,7 @@ public class AtomServiceImpl implements AtomService {
     private static final Logger logger = LoggerFactory.getLogger(AtomServiceImpl.class);
     private final AtomRepository atomRepository;
     private final AtomMapper atomMapper;
+    private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
 
     @Override
     public AtomResponseDto create(AtomRequestDto dto) {
@@ -91,10 +95,14 @@ public class AtomServiceImpl implements AtomService {
     }
 
     @Override
+    @CacheEvict(value = "atomList",  allEntries = true)
     public void deleteById(UUID id) {
         SkillAtomEntity atom = findById(id)
                 .orElseThrow( () -> new AtomNotFoundException("A Skill atom provided doesn't exist")
                 );
+        // first delete all the reference
+        List<CapsuleAtomMappingEntity> mappings = capsuleAtomMappingRepository.findBySkillAtomId(id);
+        capsuleAtomMappingRepository.deleteAll(mappings);
 
         logger.info("Skill atom {} deleted", atom.getName());
 

--- a/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
@@ -38,6 +38,7 @@ public class AtomServiceImpl implements AtomService {
     private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
 
     @Override
+    @CacheEvict(value = "atomList",  allEntries = true)
     public AtomResponseDto create(AtomRequestDto dto) {
         if(findByName(dto.getName()).isPresent()){
             throw new AtomExistsException(

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -38,6 +38,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     private final AtomRepository atomRepository;
     private final TagRepository tagRepository;
     private final ClusterRepository clusterRepository;
+    private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
 
     @Override
     public CapsuleResponseDto create(CapsuleRequestDto dto) {
@@ -121,11 +122,14 @@ public class CapsuleServiceImpl implements CapsuleService {
     }
 
     @Override
-    @CacheEvict(value = "capsuleList", key = "#id")
+    @CacheEvict(value = "capsuleList", allEntries = true)
     public void deleteById(UUID id) {
         SkillCapsuleEntity capsule = findById(id)
                 .orElseThrow( () -> new CapsuleNotFoundException("A Skill capsule provided doesn't exist")
                 );
+        // first delete all the reference
+        List<TrackCapsuleMappingEntity> mappings = trackCapsuleMappingRepository.findBySkillCapsuleId(id);
+        trackCapsuleMappingRepository.deleteAll(mappings);
 
         logger.info("Skill capsule {} deleted", capsule.getName());
 
@@ -144,7 +148,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     @Override
     @Caching(
             evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
-            put = @CachePut(value = "capsule", key = "#result.id") // Different cache name for individual capsule
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
     )
     public CapsuleResponseDto partialUpdate(CapsuleUpdateRequestDto dto, UUID id) {
         SkillCapsuleEntity capsule = findById(id)
@@ -202,7 +206,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     @Override
     @Caching(
             evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
-            put = @CachePut(value = "capsule", key = "#result.id") // Different cache name for individual capsule
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
     )
     public CapsuleResponseDto updateStatus(Status status, UUID id) {
         SkillCapsuleEntity capsule = findById(id)
@@ -221,7 +225,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     @Override
     @Caching(
             evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
-            put = @CachePut(value = "capsule", key = "#result.id") // Different cache name for individual capsule
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
     )
     public CapsuleResponseDto assignAtomToCapsule(UUID capsuleId, AtomIdsRequestDto dto){
         SkillCapsuleEntity capsuleEntity = findById(capsuleId)
@@ -273,7 +277,10 @@ public class CapsuleServiceImpl implements CapsuleService {
 
     @Override
     @Transactional
-    @Caching(evict = @CacheEvict(value = "capsuleList", key = "#result.id"))
+    @Caching(
+            evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
+    )
     public CapsuleResponseDto removeAtomFromCapsule(UUID capsuleId, UUID atomId) {
         SkillCapsuleEntity capsuleEntity = findById(capsuleId)
                 .orElseThrow(() -> new CapsuleNotFoundException("A Skill capsule provided doesn't exist"));
@@ -300,7 +307,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     @Override
     @Caching(
             evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
-            put = @CachePut(value = "capsule", key = "#result.id") // Different cache name for individual capsule
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
     )
     public CapsuleResponseDto reorderAtoms(UUID capsuleId, List<UUID> orderedAtomIds) {
         SkillCapsuleEntity capsuleEntity = findById(capsuleId)
@@ -381,7 +388,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     @Override
     @Caching(
             evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
-            put = @CachePut(value = "capsule", key = "#result.id") // Different cache name for individual capsule
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
     )
     public CapsuleResponseDto assignTagToCapsule(UUID capsuleId, TagIdsRequestDto dto){
         SkillCapsuleEntity capsuleEntity = findById(capsuleId)
@@ -400,7 +407,10 @@ public class CapsuleServiceImpl implements CapsuleService {
 
     @Override
     @Transactional
-    @Caching(evict = @CacheEvict(value = "capsuleList", key = "#result.id"))
+    @Caching(
+            evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
+    )
     public CapsuleResponseDto removeTagFromCapsule(UUID capsuleId, UUID tagId) {
         SkillCapsuleEntity capsuleEntity = findById(capsuleId)
                 .orElseThrow(() -> new CapsuleNotFoundException("A Skill capsule provided doesn't exist"));
@@ -422,7 +432,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     @Override
     @Caching(
             evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
-            put = @CachePut(value = "capsule", key = "#result.id") // Different cache name for individual capsule
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
     )
     public CapsuleResponseDto assignClusterToCapsule(UUID capsuleId, ClusterIdsRequestDto dto){
         SkillCapsuleEntity capsuleEntity = findById(capsuleId)
@@ -441,7 +451,10 @@ public class CapsuleServiceImpl implements CapsuleService {
 
     @Override
     @Transactional
-    @Caching(evict = @CacheEvict(value = "capsuleList", key = "#result.id"))
+    @Caching(
+            evict = @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "capsuleWithDetails", key = "#result.id") // Different cache name for individual capsule
+    )
     public CapsuleResponseDto removeClusterFromCapsule(UUID capsuleId, UUID clusterId) {
         SkillCapsuleEntity capsuleEntity = findById(capsuleId)
                 .orElseThrow(() -> new CapsuleNotFoundException("A Skill capsule provided doesn't exist"));

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -41,6 +41,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
 
     @Override
+    @CacheEvict(value = "capsuleList",  allEntries = true)
     public CapsuleResponseDto create(CapsuleRequestDto dto) {
         if(findByName(dto.getName()).isPresent()){
             throw new CapsuleExistsException(

--- a/src/main/java/com/capstone/skill_service/service/impl/ClusterServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/ClusterServiceImpl.java
@@ -45,6 +45,7 @@ public class ClusterServiceImpl implements ClusterService {
     private final FileStorageService fileStorageService;
 
     @Override
+    @CacheEvict(value = "clusterList",allEntries = true)
     public ClusterResponseDto create(ClusterRequestDto dto, MultipartFile image) {
         if(findByName(dto.getName()).isPresent()){
             throw new ClusterExistsException(
@@ -56,9 +57,9 @@ public class ClusterServiceImpl implements ClusterService {
         clusterEntity.setCreatedAt(LocalDateTime.now());
         clusterEntity.setUpdatedAt(LocalDateTime.now());
         clusterEntity.setStatus(Status.ACTIVE);
-        if(image != null){
+       /* if(image != null){
             clusterEntity.setImageName(getImageName(image)); //upload image
-        }
+        } */
 
         logger.info("Admin created skill cluster: {}", clusterEntity.getName());
 
@@ -103,7 +104,7 @@ public class ClusterServiceImpl implements ClusterService {
     }
 
     @Override
-    @CacheEvict(value = "clusterList", key = "#id")
+    @CacheEvict(value = "clusterList",allEntries = true)
     public void deleteById(UUID id) {
         ClusterEntity cluster = findById(id)
                 .orElseThrow( () -> new ClusterNotFoundException("A cluster provided doesn't exist")

--- a/src/main/java/com/capstone/skill_service/service/impl/TagServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TagServiceImpl.java
@@ -14,7 +14,10 @@ import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -31,6 +34,7 @@ public class TagServiceImpl implements TagService {
     private final TagMapper tagMapper;
 
     @Override
+    @CacheEvict(value = "tagList", allEntries = true)
     public TagResponseDto create(TagRequestDto dto) {
         if(findByName(dto.getName()).isPresent()){
             throw new TagExistsException(
@@ -77,6 +81,7 @@ public class TagServiceImpl implements TagService {
     }
 
     @Override
+    @CacheEvict(value = "capsuleList", allEntries = true)
     public void deleteById(UUID id) {
         TagEntity tag = findById(id)
                 .orElseThrow( () -> new TagNotFoundException("A tag provided doesn't exist")
@@ -88,6 +93,7 @@ public class TagServiceImpl implements TagService {
     }
 
     @Override
+    @Cacheable(value = "tag", key = "#id")
     public TagResponseDto getTag(UUID id) {
         TagEntity tag = findById(id)
                 .orElseThrow( () -> new TagNotFoundException("A tag provided doesn't exist")
@@ -99,6 +105,10 @@ public class TagServiceImpl implements TagService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "tagList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "tag", key = "#result.id") // Different cache name for individual track
+    )
     public TagResponseDto partialUpdate(TagUpdateRequestDto dto, UUID id) {
         TagEntity tag = findById(id)
                 .orElseThrow( () -> new TagNotFoundException("A tag provided doesn't exist")
@@ -128,6 +138,10 @@ public class TagServiceImpl implements TagService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "tagList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "tag", key = "#result.id") // Different cache name for individual track
+    )
     public TagResponseDto updateStatus(Status status, UUID id) {
         TagEntity tag = findById(id)
                 .orElseThrow( () -> new TagNotFoundException("A tag provided doesn't exist")

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -37,8 +37,10 @@ public class TrackServiceImpl implements TrackService {
     private final CapsuleMapper capsuleMapper;
     private final CapsuleService capsuleService;
     private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
+    private final RouteTrackMappingRepository routeTrackMappingRepository;
 
     @Override
+    @CacheEvict(value = "growthTrackList",  allEntries = true)
     public TrackResponseDto create(TrackRequestDto dto) {
         if(findByName(dto.getName()).isPresent()){
             throw new TrackExistsException(
@@ -123,7 +125,7 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
-    @Cacheable(value = "growthTrack", key = "#trackId")
+    @Cacheable(value = "track", key = "#trackId")
     public TrackWithCapsuleResponseDto getTrackWithCapsules(UUID trackId) {
         GrowthTrackEntity track = trackRepository.findByIdWithCapsules(trackId)
                 .orElseThrow(() -> new TrackNotFoundException("A Growth Track not found"));
@@ -172,6 +174,7 @@ public class TrackServiceImpl implements TrackService {
 
 
     @Override
+    @Cacheable(value = "track", key = "#id")
     public TrackResponseDto getTrack(UUID id) {
         GrowthTrackEntity track = findById(id)
                 .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
@@ -183,19 +186,23 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
+    @CacheEvict(value = "growthTrackList", allEntries = true)
     public void deleteById(UUID id) {
         GrowthTrackEntity track = findById(id)
                 .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
                 );
+        // first delete all the reference
+        List<RouteTrackMappingEntity> mappings = routeTrackMappingRepository.findByTrackId(id);
+        routeTrackMappingRepository.deleteAll(mappings);
 
         logger.info("Growth track {} deleted", track.getName());
 
-        this.capsuleRepository.deleteById(id);
+        this.trackRepository.deleteById(id);
     }
 
     @Override
     @Caching(
-            evict = @CacheEvict(value = "trackList", allEntries = true), // to update the entire list
+            evict = @CacheEvict(value = "growthTrackList", allEntries = true), // to update the entire list
             put = @CachePut(value = "track", key = "#result.id") // Different cache name for individual track
     )
     public TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id) {
@@ -235,6 +242,10 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "growthTrackList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "track", key = "#result.id") // Different cache name for individual track
+    )
     public TrackResponseDto updateStatus(Status status, UUID id) {
         GrowthTrackEntity track = findById(id)
                 .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
@@ -247,7 +258,7 @@ public class TrackServiceImpl implements TrackService {
 
     @Override
     @Caching(
-            evict = @CacheEvict(value = "trackList", allEntries = true), // to update the entire list
+            evict = @CacheEvict(value = "growthTrackList", allEntries = true), // to update the entire list
             put = @CachePut(value = "track", key = "#result.id") // Different cache name for individual track
     )
     public TrackResponseDto assignCapsuleToTrack(UUID trackId, CapsuleIdsRequestDto dto) {
@@ -264,6 +275,10 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "growthTrackList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "track", key = "#result.id") // Different cache name for individual track
+    )
     public TrackResponseDto removeCapsuleFromTrack(UUID trackId, UUID capsuleId) {
         GrowthTrackEntity trackEntity = findById(trackId)
                 .orElseThrow(() -> new TrackNotFoundException("A growth track provided doesn't exist"));
@@ -288,6 +303,10 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "growthTrackList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "track", key = "#result.id") // Different cache name for individual track
+    )
     public TrackResponseDto reorderCapsules(UUID trackId, List<UUID> orderedCapsuleIds) {
         GrowthTrackEntity trackEntity = findById(trackId)
                 .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")


### PR DESCRIPTION
# 🚀 Pull Request: Safe deletion for associated entities

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Skill taxonomy management.](https://amali-tech.atlassian.net/browse/VER-19)

---

## ✅ Summary

This PR improves data consistency when deleting an associated entity, such as a tag, cluster, atom and etc. These changes ensure that all the mappings or associated data of a particular entity have been deleted first before deleting the actual data. Additionally, upon creation, update, and deletion, data are immediately updated in cache. 

---

## 📌 Feature

- [x] Safe deletion on tag, cluster, atom, capsule, and growth track
- [x] Update caching data upon creation, update, and delete of data

---

## 🚧 Next Task

- Double-check each fetching level(talent route and growth track) DB queries request and optimize it