### PR TITLE
Inheance time complexity when fetching skill taxonomy hierarchy

### DIFF
--- a/src/main/java/com/capstone/skill_service/mapper/CapsuleMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/CapsuleMapper.java
@@ -30,7 +30,7 @@ public interface CapsuleMapper {
     @Mapping(target = "difficulty", source = "capsule.difficulty")
     @Mapping(target = "proficiencyLevel", source = "capsule.proficiencyLevel")
     @Mapping(target = "description", source = "capsule.description")
-    @Mapping(target = "skillAtoms", source = "capsule.skillAtoms")
+    @Mapping(target = "skillAtoms", ignore = true) // to avoid N+1 caused by capsule.skillAtoms. service handles it
     @Mapping(target = "sequenceOrder", source = "sequenceOrder")
     CapsuleInSequenceOrderResponseDto toInSequenceOrderDto(TrackCapsuleMappingEntity mapping);
 

--- a/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
@@ -9,13 +9,13 @@ import com.capstone.skill_service.model.TalentRouteEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = TrackMapper.class)
 public interface RouteMapper {
     @Mapping(target = "tracks", source = "tracks")
     RouteResponseDto toDto(TalentRouteEntity entity);
 
     TalentRouteEntity toEntity(RouteRequestDto dto);
-    @Mapping(target = "tracks",  ignore = true)
+    @Mapping(target = "tracks",  source = "tracks")
     RouteWithTrackResponseDto toWithTrackDto(TalentRouteEntity entity);
 
     @Mapping(target = "id", source = "growthTrack.id")

--- a/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
@@ -11,13 +11,13 @@ import com.capstone.skill_service.model.TrackCapsuleMappingEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = CapsuleMapper.class)
 public interface TrackMapper {
     @Mapping(target = "capsules", source = "skillCapsules")
     TrackResponseDto toDto(GrowthTrackEntity entity);
 
     GrowthTrackEntity toEntity(TrackRequestDto dto);
-    @Mapping(target = "capsules",  ignore = true)
+    @Mapping(target = "capsules",  source = "skillCapsules")
     TrackWithCapsuleResponseDto toWithCapsuleDto(GrowthTrackEntity entity);
 
     @Mapping(target = "id", source = "capsule.id")

--- a/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
@@ -31,7 +31,7 @@ public interface TrackMapper {
     @Mapping(target = "estimatedMonths", source = "growthTrack.estimatedMonths")
     @Mapping(target = "status", source = "growthTrack.status")
     @Mapping(target = "description", source = "growthTrack.description")
-    @Mapping(target = "capsules", source = "growthTrack.skillCapsules")
+    @Mapping(target = "capsules", ignore = true)
     @Mapping(target = "sequenceOrder", source = "sequenceOrder")
     TrackInSequenceOrderResponseDto toInSequenceOrderDto(RouteTrackMappingEntity mapping);
 

--- a/src/main/java/com/capstone/skill_service/repository/CapsuleAtomMappingRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/CapsuleAtomMappingRepository.java
@@ -1,14 +1,12 @@
 package com.capstone.skill_service.repository;
 
 import com.capstone.skill_service.model.CapsuleAtomMappingEntity;
-import com.capstone.skill_service.model.SkillAtomEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository

--- a/src/main/java/com/capstone/skill_service/repository/RouteRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/RouteRepository.java
@@ -1,6 +1,5 @@
 package com.capstone.skill_service.repository;
 
-import com.capstone.skill_service.model.GrowthTrackEntity;
 import com.capstone.skill_service.model.TalentRouteEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,8 +19,9 @@ public interface RouteRepository extends JpaRepository<TalentRouteEntity, UUID> 
     @Query("""
         SELECT tr
         FROM TalentRouteEntity tr
-        LEFT JOIN FETCH tr.tracks gt
-        where tr.id = :id
+        LEFT JOIN FETCH tr.tracks mt
+        LEFT JOIN FETCH mt.growthTrack gt
+        WHERE tr.id = :id
     """)
     Optional<TalentRouteEntity> findByIdWithGrowthTracks(@Param("id") UUID id);
 

--- a/src/main/java/com/capstone/skill_service/repository/TrackCapsuleMappingRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackCapsuleMappingRepository.java
@@ -15,10 +15,10 @@ public interface TrackCapsuleMappingRepository extends JpaRepository<TrackCapsul
     SELECT tc
     FROM TrackCapsuleMappingEntity tc
     JOIN FETCH tc.capsule
-    WHERE tc.growthTrack.id = :trackId
-    ORDER BY tc.growthTrack.id, tc.sequenceOrder
+    WHERE tc.growthTrack.id IN :trackIds
+    ORDER BY tc.sequenceOrder
 """)
-    List<TrackCapsuleMappingEntity> findByTrackIdsWithCapsules(@Param("trackId") UUID trackId);
+    List<TrackCapsuleMappingEntity> findByTrackIdsWithCapsules(@Param("trackIds") List<UUID> trackIds);
 
     @Query("""
     SELECT tc

--- a/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
@@ -18,12 +18,14 @@ public interface TrackRepository extends JpaRepository<GrowthTrackEntity, UUID> 
     Optional<GrowthTrackEntity> findByName(String name);
 
     @Query("""
-        SELECT gt
+        SELECT DISTINCT gt
         FROM GrowthTrackEntity gt
-        LEFT JOIN FETCH gt.skillCapsules c
-        where gt.id = :id
+        LEFT JOIN FETCH gt.skillCapsules cm
+        LEFT JOIN FETCH cm.capsule c
+        WHERE gt.id = :trackId
+        ORDER BY cm.sequenceOrder
     """)
-    Optional<GrowthTrackEntity> findByIdWithCapsules(@Param("id") UUID id);
+    Optional<GrowthTrackEntity> findByIdWithCapsules(@Param("trackId") UUID trackId);
 
     @Query("""
         SELECT gt FROM GrowthTrackEntity gt

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -1,28 +1,36 @@
 package com.capstone.skill_service.service.impl;
 
 import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.atom.AtomInSequenceOrderResponseDto;
+import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.route.RouteRequestDto;
 import com.capstone.skill_service.dto.route.RouteResponseDto;
 import com.capstone.skill_service.dto.route.RouteUpdateRequestDto;
 import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
 import com.capstone.skill_service.dto.track.*;
 import com.capstone.skill_service.exception.*;
+import com.capstone.skill_service.mapper.AtomMapper;
+import com.capstone.skill_service.mapper.CapsuleMapper;
 import com.capstone.skill_service.mapper.RouteMapper;
+import com.capstone.skill_service.mapper.TrackMapper;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
 import com.capstone.skill_service.service.RouteService;
-import com.capstone.skill_service.service.TrackService;
 import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,12 +39,15 @@ public class RouteServiceImpl implements RouteService {
     private final TrackRepository trackRepository;
     private final RouteRepository routeRepository;
     private final RouteMapper routeMapper;
-    private final RouteTrackMappingRepository routeTrackMappingRepository;
-    private final TrackService trackService;
-
+    private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
+    private final CapsuleMapper capsuleMapper;
+    private final TrackMapper trackMapper;
+    private final AtomMapper atomMapper;
+    private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
 
 
     @Override
+    @CacheEvict(value = "talentRouteList",  allEntries = true)
     public RouteResponseDto create(RouteRequestDto dto) {
         if(findByName(dto.getName()).isPresent()){
             throw new RouteExistsException(
@@ -150,8 +161,7 @@ public class RouteServiceImpl implements RouteService {
                 .orElseThrow(() -> new RouteNotFoundException("A Talent Route not found"));
 
         // get mappings (growth track and sequence order)
-        List<RouteTrackMappingEntity> mappings =
-                routeTrackMappingRepository.findByTrackIdsWithCapsules(routeId);
+        List<RouteTrackMappingEntity> mappings = route.getTracks();
 
         if (mappings.isEmpty()) {
             RouteWithTrackResponseDto dto = routeMapper.toWithTrackDto(route);
@@ -159,39 +169,73 @@ public class RouteServiceImpl implements RouteService {
             return dto;
         }
 
+        // fetch capsules in growth track
+        List<UUID> trackIds = mappings.stream()
+                .map(m -> m.getGrowthTrack().getId())
+                .toList();
+        // fetch each growth track with its capsule
+        Map<UUID, List<CapsuleInSequenceOrderResponseDto>> capsuleByGrowthTrack = getCapsulesByGrowthTrack(trackIds);
+
         // fetch each growth track with its capsules
-        List<TrackInSequenceOrderResponseDto> growthTrackInSequenceOrder = getGrowthTrackInSequenceOrder(mappings);
+        List<TrackInSequenceOrderResponseDto> growthTrackInSequenceOrder = getGrowthTrackInSequenceOrder(mappings, capsuleByGrowthTrack);
 
         // build final response
         RouteWithTrackResponseDto dto = routeMapper.toWithTrackDto(route);
         dto.setTracks(growthTrackInSequenceOrder);
         return dto;
     }
+    public Map<UUID, List<CapsuleInSequenceOrderResponseDto>> getCapsulesByGrowthTrack(List<UUID> trackIds){
+        List<TrackCapsuleMappingEntity> mappings = trackCapsuleMappingRepository.findByTrackIdsWithCapsules(trackIds);
 
-    public List<TrackInSequenceOrderResponseDto> getGrowthTrackInSequenceOrder(List<RouteTrackMappingEntity> mappings ){
+        // start fetching capsules' atoms
+        List<UUID> capsuleIds = mappings.stream()
+                .map(m -> m.getCapsule().getId())
+                .toList();
+        Map<UUID, List<AtomInSequenceOrderResponseDto>> atomsByCapsule = getAtomsByCapsule(capsuleIds);
+
+        // group capsule by growth track
+        return mappings.stream()
+                .collect(Collectors.groupingBy(
+                        m -> m.getGrowthTrack().getId(),
+                        LinkedHashMap::new,
+                        Collectors.mapping(
+                                m -> {
+                                    // inject atom in capsule as well
+                                    CapsuleInSequenceOrderResponseDto dto = capsuleMapper.toInSequenceOrderDto(m);
+                                    dto.setSkillAtoms(atomsByCapsule.getOrDefault(m.getCapsule().getId(), List.of()));
+                                    return dto;
+                                }, Collectors.toList())
+                ));
+    }
+
+    public Map<UUID, List<AtomInSequenceOrderResponseDto>> getAtomsByCapsule(List<UUID> capsuleIds){
+        List<CapsuleAtomMappingEntity> mappings = capsuleAtomMappingRepository.findByCapsuleIdsWithAtoms(capsuleIds);
+
+        // group atoms by capsule
+        return mappings.stream()
+                .collect(Collectors.groupingBy(
+                        m -> m.getCapsule().getId(),
+                        LinkedHashMap::new,
+                        Collectors.mapping(atomMapper::toInSequenceOrderDto, Collectors.toList())
+                ));
+    }
+
+    public List<TrackInSequenceOrderResponseDto> getGrowthTrackInSequenceOrder(List<RouteTrackMappingEntity> mappings, Map<UUID, List<CapsuleInSequenceOrderResponseDto>> capsuleByGrowthTrack  ){
         return mappings.stream()
                 .map(mapping -> {
                     GrowthTrackEntity track = mapping.getGrowthTrack();
 
-                    // get each growth track from growth track service
-                    TrackWithCapsuleResponseDto trackWithCapsules =
-                            trackService.getTrackWithCapsules(track.getId());
+                    TrackInSequenceOrderResponseDto dto = trackMapper.toInSequenceOrderDto(mapping);
+                    dto.setSequenceOrder(mapping.getSequenceOrder()); // link the sequence order
+                    dto.setCapsules(capsuleByGrowthTrack.getOrDefault(track.getId(), List.of()));
 
-                    // wrap in dto that is in routeResponseDto
-                    TrackInSequenceOrderResponseDto dto = new TrackInSequenceOrderResponseDto();
-                    dto.setId(trackWithCapsules.getId());
-                    dto.setName(trackWithCapsules.getName());
-                    dto.setDescription(trackWithCapsules.getDescription());
-                    dto.setEstimatedMonths(trackWithCapsules.getEstimatedMonths());
-                    dto.setStatus(trackWithCapsules.getStatus());
-                    dto.setCapsules(trackWithCapsules.getCapsules());
-                    dto.setSequenceOrder(mapping.getSequenceOrder());
                     return dto;
                 })
                 .toList();
     }
 
     @Override
+    @CacheEvict(value = "talentRouteList",  allEntries = true)
     public void deleteById(UUID id) {
         TalentRouteEntity route = findById(id)
                 .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")
@@ -203,6 +247,10 @@ public class RouteServiceImpl implements RouteService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "talentRouteList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "talentRoute", key = "#result.id") // Different cache name for individual track
+    )
     public RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, UUID id) {
         TalentRouteEntity route = findById(id)
                 .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")
@@ -246,6 +294,10 @@ public class RouteServiceImpl implements RouteService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "talentRouteList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "talentRoute", key = "#result.id") // Different cache name for individual track
+    )
     public RouteResponseDto updateStatus(Status status, UUID id) {
 
         TalentRouteEntity route = findById(id)
@@ -258,6 +310,10 @@ public class RouteServiceImpl implements RouteService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "talentRouteList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "talentRoute", key = "#result.id") // Different cache name for individual track
+    )
     public RouteResponseDto assignTrackToRoute(UUID routeId, TrackIdsRequestDto dto) {
 
         TalentRouteEntity route = findById(routeId)
@@ -273,6 +329,10 @@ public class RouteServiceImpl implements RouteService {
     }
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "talentRouteList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "talentRoute", key = "#result.id") // Different cache name for individual track
+    )
     public RouteResponseDto removeTrackFromRoute(UUID routeId, UUID trackId) {
 
         TalentRouteEntity route = findById(routeId)
@@ -299,6 +359,10 @@ public class RouteServiceImpl implements RouteService {
 
 
     @Override
+    @Caching(
+            evict = @CacheEvict(value = "talentRouteList", allEntries = true), // to update the entire list
+            put = @CachePut(value = "talentRoute", key = "#result.id") // Different cache name for individual track
+    )
     public RouteResponseDto reorderTracks(UUID trackId, List<UUID> orderedTrackIds) {
         TalentRouteEntity route = findById(trackId)
                 .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -1,16 +1,16 @@
 package com.capstone.skill_service.service.impl;
 
 import com.capstone.skill_service.dto.CustomPageResponse;
+import com.capstone.skill_service.dto.atom.AtomInSequenceOrderResponseDto;
 import com.capstone.skill_service.dto.capsule.CapsuleIdsRequestDto;
 import com.capstone.skill_service.dto.capsule.CapsuleInSequenceOrderResponseDto;
-import com.capstone.skill_service.dto.capsule.CapsuleWithDetailsResponseDto;
 import com.capstone.skill_service.dto.track.*;
 import com.capstone.skill_service.exception.*;
+import com.capstone.skill_service.mapper.AtomMapper;
 import com.capstone.skill_service.mapper.CapsuleMapper;
 import com.capstone.skill_service.mapper.TrackMapper;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
-import com.capstone.skill_service.service.CapsuleService;
 import com.capstone.skill_service.service.TrackService;
 import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -34,10 +35,10 @@ public class TrackServiceImpl implements TrackService {
     private final CapsuleRepository capsuleRepository;
     private final TrackRepository trackRepository;
     private final TrackMapper trackMapper;
+    private final AtomMapper atomMapper;
     private final CapsuleMapper capsuleMapper;
-    private final CapsuleService capsuleService;
-    private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
     private final RouteTrackMappingRepository routeTrackMappingRepository;
+    private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
 
     @Override
     @CacheEvict(value = "growthTrackList",  allEntries = true)
@@ -131,47 +132,52 @@ public class TrackServiceImpl implements TrackService {
                 .orElseThrow(() -> new TrackNotFoundException("A Growth Track not found"));
 
         // get mappings (capsule and sequence order)
-        List<TrackCapsuleMappingEntity> mappings =
-                trackCapsuleMappingRepository.findByTrackIdsWithCapsules(trackId);
-
+        List<TrackCapsuleMappingEntity> mappings = track.getSkillCapsules();
         if (mappings.isEmpty()) {
             TrackWithCapsuleResponseDto dto = trackMapper.toWithCapsuleDto(track);
             dto.setCapsules(List.of()); // return empty list in capsule field
             return dto;
         }
+
+
+        // fetch capsules in growth track
+        List<UUID> capsuleIds = mappings.stream()
+                .map(m -> m.getCapsule().getId())
+                .toList();
         // fetch each capsule with its atoms
-        List<CapsuleInSequenceOrderResponseDto> capsuleInSequenceOrder=getCapsuleInSequenceOrder(mappings);
+        Map<UUID, List<AtomInSequenceOrderResponseDto>> atomsByCapsule = getAtomsByCapsule(capsuleIds);
+        List<CapsuleInSequenceOrderResponseDto> capsuleInSequenceOrder=getCapsuleInSequenceOrder(mappings,atomsByCapsule);
 
         // build final response
         TrackWithCapsuleResponseDto dto = trackMapper.toWithCapsuleDto(track);
         dto.setCapsules(capsuleInSequenceOrder);
+
         return dto;
     }
-    public List<CapsuleInSequenceOrderResponseDto> getCapsuleInSequenceOrder(List<TrackCapsuleMappingEntity> mappings ){
+    public Map<UUID, List<AtomInSequenceOrderResponseDto>> getAtomsByCapsule(List<UUID> capsuleIds){
+        List<CapsuleAtomMappingEntity> mappings = capsuleAtomMappingRepository.findByCapsuleIdsWithAtoms(capsuleIds);
+
+        // group atoms by capsule
+        return mappings.stream()
+                .collect(Collectors.groupingBy(
+                        m -> m.getCapsule().getId(),
+                        LinkedHashMap::new,
+                        Collectors.mapping(atomMapper::toInSequenceOrderDto, Collectors.toList())
+                ));
+    }
+    public List<CapsuleInSequenceOrderResponseDto> getCapsuleInSequenceOrder(List<TrackCapsuleMappingEntity> mappings, Map<UUID, List<AtomInSequenceOrderResponseDto>> atomsByCapsule ){
         return mappings.stream()
                 .map(mapping -> {
                     SkillCapsuleEntity capsule = mapping.getCapsule();
-                    //get capsule with atom
-                    CapsuleWithDetailsResponseDto capsuleWithDetails= capsuleService.getCapsuleWithDetails(capsule.getId());
 
-                    // wrap capsule in response with sequence order dto
-                    CapsuleInSequenceOrderResponseDto capsuleInSequence = new CapsuleInSequenceOrderResponseDto();
-                    capsuleInSequence.setId(capsuleWithDetails.getId());
-                    capsuleInSequence.setName(capsuleWithDetails.getName());
-                    capsuleInSequence.setDescription(capsuleWithDetails.getDescription());
-                    capsuleInSequence.setEstimatedHours(capsuleWithDetails.getEstimatedHours());
-                    capsuleInSequence.setDifficulty(capsuleWithDetails.getDifficulty());
-                    capsuleInSequence.setProficiencyLevel(capsuleWithDetails.getProficiencyLevel());
-                    capsuleInSequence.setSequenceOrder(mapping.getSequenceOrder());
-                    capsuleInSequence.setSkillAtoms(capsuleWithDetails.getSkillAtoms());
+                    CapsuleInSequenceOrderResponseDto dto = capsuleMapper.toInSequenceOrderDto(mapping);
+                    dto.setSequenceOrder(mapping.getSequenceOrder()); // link the sequence order
+                    dto.setSkillAtoms(atomsByCapsule.getOrDefault(capsule.getId(), List.of()));
 
-                    return capsuleInSequence;
+                    return dto;
                 })
                 .toList();
     }
-
-
-
 
     @Override
     @Cacheable(value = "track", key = "#id")


### PR DESCRIPTION
# 🚀 Pull Request: Optimize fetching query

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Skill taxonomy management.](https://amali-tech.atlassian.net/browse/VER-19)

---

## ✅ Summary

This PR optimizes the retrieval of the skill taxonomy hierarchy by eliminating N+1 queries.
Previously, fetching talent route or growth tracks with their capsules and atoms required multiple queries, which led to linear time complexity (O(n)). With this update, the hierarchy is fetched in a constant number of queries, improving performance to constant time (O(1)) and ensuring more efficient data access.

---

## 📌 Improving

- [x] Growth track retrieval
- [x] Talent route retrieval

---

## 🚧 Next Task

- Working on uploading images for the cluster on a third party. (Not priority)