### PR TITLE
ci: add Java checks workflow for skill-service-versapath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI skill-service-versapath
+name: CI - Java checks
 
 on:
   pull_request:
@@ -7,26 +7,18 @@ on:
     branches: [dev]
 
 jobs:
-  build-test:
+  java-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21 and configure Maven auth for package registry
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
           cache: maven
-          server-id: github             # must match <id> in your pom.xml repositories
-          # Prefer an explicit PACKAGES_TOKEN / PACKAGES_USER (PAT) when provided
-          # Fall back to the runner-provided token and actor when appropriate
-          server-username: ${{ secrets.PACKAGES_USER || github.actor }}
-          server-password: ${{ secrets.PACKAGES_TOKEN || github.token }}
-
-      - name: Verify external package access
-        run: mvn -B -DskipTests dependency:resolve
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -35,6 +27,9 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
+
+      - name: Verify dependencies
+        run: mvn -B -DskipTests dependency:resolve
 
       - name: Build with Maven
         run: mvn -B clean install


### PR DESCRIPTION
Adds a minimal CI pipeline to run Java/Maven checks.