### PR TITLE
Send an event to create skill structure on Moodle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
 		<java.version>21</java.version>
 		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
+<!--	common event repository-->
+	<repositories>
+		<repository>
+			<id>github</id>
+			<url>https://maven.pkg.github.com/karangwaajika/versapath-events</url>
+		</repository>
+	</repositories>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -98,6 +105,17 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+<!--		RabbitMQ-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
+<!--		Common event-->
+		<dependency>
+			<groupId>org.common</groupId>
+			<artifactId>versapath-events</artifactId>
+			<version>1.8.9</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/capstone/skill_service/config/RabbitMQConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/RabbitMQConfig.java
@@ -1,0 +1,30 @@
+package com.capstone.skill_service.config;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    @Bean
+    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                         Jackson2JsonMessageConverter messageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(messageConverter);
+        return template;
+    }
+
+    @Bean
+    public Queue createSkillQueue() {
+        return new Queue("versapath.skill.create", true);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/messaging/CreateSkillProducerEvent.java
+++ b/src/main/java/com/capstone/skill_service/messaging/CreateSkillProducerEvent.java
@@ -1,0 +1,20 @@
+package com.capstone.skill_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.CreateSkillEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateSkillProducerEvent {
+    private static final Logger logger = LoggerFactory.getLogger(CreateSkillProducerEvent.class);
+    private final RabbitTemplate rabbitTemplate;
+    public void sendCreateSkillOnMoodleCommand(CreateSkillEvent createEvent) {
+        logger.info("Send command to create skill structure on Moodle: {}", createEvent.getCapsuleName());
+
+        rabbitTemplate.convertAndSend("versapath.skill.create", createEvent);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -9,11 +9,14 @@ import com.capstone.skill_service.dto.tag.TagIdsRequestDto;
 import com.capstone.skill_service.exception.*;
 import com.capstone.skill_service.mapper.AtomMapper;
 import com.capstone.skill_service.mapper.CapsuleMapper;
+import com.capstone.skill_service.messaging.CreateSkillProducerEvent;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
 import com.capstone.skill_service.service.CapsuleService;
 import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
+import org.common.event.CreateSkillEvent;
+import org.common.event.SkillAtom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
@@ -39,6 +42,7 @@ public class CapsuleServiceImpl implements CapsuleService {
     private final TagRepository tagRepository;
     private final ClusterRepository clusterRepository;
     private final TrackCapsuleMappingRepository trackCapsuleMappingRepository;
+    private final CreateSkillProducerEvent createSkillProducerEvent;
 
     @Override
     @CacheEvict(value = "capsuleList",  allEntries = true)
@@ -63,8 +67,30 @@ public class CapsuleServiceImpl implements CapsuleService {
         logger.info("Admin created skill capsule: {}", capsuleEntity.getName());
         SkillCapsuleEntity savedCapsule = capsuleRepository.save(capsuleEntity);
 
+        // send an event command
+        sendEventToCreateSkillStructureOnMoodle(savedCapsule);
+
         // map capsule to response dto
         return mapCapsuleToResponseDtoWithAtom(savedCapsule);
+    }
+
+    void sendEventToCreateSkillStructureOnMoodle(SkillCapsuleEntity savedCapsule){
+        // extract capsule atom names to send to Moodle
+        List<SkillAtomEntity> atomEntities = savedCapsule.getSkillAtoms().stream()
+                .map(CapsuleAtomMappingEntity::getAtom)
+                .toList();
+
+        List<String> atomNames = new ArrayList<>();
+        for(SkillAtomEntity atom: atomEntities){
+            atomNames.add(atom.getName());
+        }
+
+        CreateSkillEvent createSkillEvent = CreateSkillEvent.builder()
+                .capsuleName(savedCapsule.getName())
+                .atoms(atomNames)
+                .build();
+
+        createSkillProducerEvent.sendCreateSkillOnMoodleCommand(createSkillEvent);
     }
 
     public CapsuleResponseDto mapCapsuleToResponseDtoWithAtom(SkillCapsuleEntity capsule){

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,37 +4,6 @@ server:
 spring:
   application:
     name: skill-service
-  datasource:
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
 
-  data:
-    redis:
-      host: ${SPRING_REDIS_HOST}
-      port: ${SPRING_REDIS_PORT}
-
-  cache:
-    type: redis
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
   config:
     import: optional:configserver:${CONFIG_SERVER_URL}
-  main:
-    lazy-initialization: true
-
-eureka:
-  client:
-    service-url:
-      defaultZone: ${EUREKA_CLIENT_URL}
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-  endpoint:
-    health:
-      show-details: always


### PR DESCRIPTION
# 🚀 Pull Request: Produce an event to create skill structure

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-21: Send an event to create skill structure on Moodle.](https://amali-tech.atlassian.net/browse/VER-143)

---

## ✅ Summary

This PR adds functionality such that when a skill capsule is stored in the database, it instantly sends an event command to the MLS service to create the skill structure on Moodle.

---

## 📌 Improving

- [x] Configure RabbitMQ
- [x] Produce an event and send it to the MLS service.

---

## 🚧 Next Task

- Update atom and capsule data with the Moodle information coming from the MLS service.