### PR TITLE
Use environment variables to update queue and topic names

### DIFF
--- a/src/main/java/com/capstone/skill_service/config/RabbitMQConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/RabbitMQConfig.java
@@ -4,11 +4,17 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RabbitMQConfig {
+    @Value("${SKILL_CREATE_QUEUE}")
+    private String skillCreateQueue;
+
+    @Value("${SKILL_UPDATE_QUEUE}")
+    private String skillUpdateQueue;
 
     @Bean
     public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
@@ -25,6 +31,12 @@ public class RabbitMQConfig {
 
     @Bean
     public Queue createSkillQueue() {
-        return new Queue("versapath.skill.create", true);
+        return new Queue(skillCreateQueue, true);
     }
+
+    @Bean
+    public Queue updateSkillQueue() {
+        return new Queue(skillUpdateQueue, true);
+    }
+
 }

--- a/src/main/java/com/capstone/skill_service/messaging/CreateSkillProducerEvent.java
+++ b/src/main/java/com/capstone/skill_service/messaging/CreateSkillProducerEvent.java
@@ -5,16 +5,19 @@ import org.common.event.CreateSkillEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class CreateSkillProducerEvent {
+    @Value("${SKILL_CREATE_QUEUE}")
+    private String skillCreateQueue;
     private static final Logger logger = LoggerFactory.getLogger(CreateSkillProducerEvent.class);
     private final RabbitTemplate rabbitTemplate;
     public void sendCreateSkillOnMoodleCommand(CreateSkillEvent createEvent) {
         logger.info("Send command to create skill structure on Moodle: {}", createEvent);
 
-        rabbitTemplate.convertAndSend("versapath.skill.create", createEvent);
+        rabbitTemplate.convertAndSend(skillCreateQueue, createEvent);
     }
 }

--- a/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
+++ b/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
@@ -7,6 +7,7 @@ import org.common.event.SkillCapsuleEvent;
 import org.common.event.TalentRouteEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -19,26 +20,38 @@ public class PopulateSkillEvents {
     private final KafkaTemplate<String, GrowthTrackEvent> kafkaGrowthTrackTemplate;
     private final KafkaTemplate<String, TalentRouteEvent> kafkaTalentRouteTemplate;
 
+    @Value("${ATOM_CREATE_TOPIC}")
+    private String atomCreateTopic;
+
+    @Value("${CAPSULE_CREATE_TOPIC}")
+    private String capsuleCreateTopic;
+
+    @Value("${GROWTH_TRACK_CREATE_TOPIC}")
+    private String growthTrackCreateTopic;
+
+    @Value("${TALENT_ROUTE_CREATE_TOPIC}")
+    private String talentRouteCreateTopic;
+
     public void populateSkillAtom(SkillAtomEvent atomEvent){
-        kafkaAtomTemplate.send("atom.create", atomEvent);
+        kafkaAtomTemplate.send(atomCreateTopic, atomEvent);
 
         logger.info("atom event is populated: {}", atomEvent);
     }
 
     public void populateSkillCapsule(SkillCapsuleEvent capsuleEvent){
-        kafkaCapsuleTemplate.send("capsule.create", capsuleEvent);
+        kafkaCapsuleTemplate.send(capsuleCreateTopic, capsuleEvent);
 
         logger.info("capsule event is populated: {}", capsuleEvent);
     }
 
     public void populateGrowthTrack(GrowthTrackEvent growthTrackEvent){
-        kafkaGrowthTrackTemplate.send("growthTrack.create", growthTrackEvent);
+        kafkaGrowthTrackTemplate.send(growthTrackCreateTopic, growthTrackEvent);
 
         logger.info("growth track event is populated: {}", growthTrackEvent);
     }
 
     public void populateTalentRoute(TalentRouteEvent talentRouteEvent){
-        kafkaTalentRouteTemplate.send("talentRoute.create", talentRouteEvent);
+        kafkaTalentRouteTemplate.send(talentRouteCreateTopic, talentRouteEvent);
 
         logger.info("talent route event is populated: {}", talentRouteEvent);
     }

--- a/src/main/java/com/capstone/skill_service/messaging/UpdateSkillListenerEvent.java
+++ b/src/main/java/com/capstone/skill_service/messaging/UpdateSkillListenerEvent.java
@@ -14,7 +14,7 @@ public class UpdateSkillListenerEvent {
     private static final Logger logger = LoggerFactory.getLogger(UpdateSkillListenerEvent.class);
     private final CapsuleService capsuleService;
 
-    @RabbitListener(queues = "versapath.skill.update")
+    @RabbitListener(queues = "${SKILL_UPDATE_QUEUE}")
     public void handleMoodleUserCreation(UpdateSkillEvent updateSkillEvent) {
         logger.info("Start updating skills: {}", updateSkillEvent);
 

--- a/src/main/java/com/capstone/skill_service/util/FileHelper.java
+++ b/src/main/java/com/capstone/skill_service/util/FileHelper.java
@@ -6,15 +6,12 @@ import com.capstone.skill_service.exception.FileException;
 import com.capstone.skill_service.model.ClusterEntity;
 import com.capstone.skill_service.model.SkillCapsuleEntity;
 import com.capstone.skill_service.service.PreSignedUrlService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartFile;
 
 
 public class FileHelper {
-
-    @Value("${FILE_MAX_SIZE}")
-    static private int maxFileSize=10;
+    static int maxFileSize = 10;
     private FileHelper() {} // prevent initialization
     public static void validateImage(MultipartFile image) {
         long fileSize = DataSize.ofMegabytes(maxFileSize).toBytes();


### PR DESCRIPTION
These changes are applied to avoid hard-coding topic and queue names.