### PR TITLE
Handle internal communication Error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>2.2</version>
+			<version>2.2.4</version>
 		</dependency>
 <!--		Kafka-->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
 			<artifactId>s3</artifactId>
 			<version>2.20.26</version>
 		</dependency>
+<!--		websocket-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/skill_service/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/actuator/health"
+                                "/actuator/health", "/ws/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/capstone/skill_service/config/WebSocketConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/WebSocketConfig.java
@@ -1,0 +1,29 @@
+package com.capstone.skill_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // Prefix for clients to subscribe to
+        config.enableSimpleBroker("/topic", "/queue");
+        // Prefix for general messages sent to the whole app
+        config.setApplicationDestinationPrefixes("/app");
+        // Prefix for user-specific queues
+        config.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // WebSocket handshake endpoint
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*") // you can restrict to your frontend origin
+                .withSockJS();
+    }
+}

--- a/src/main/java/com/capstone/skill_service/config/WebSocketConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/WebSocketConfig.java
@@ -23,7 +23,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // WebSocket handshake endpoint
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*") // you can restrict to your frontend origin
+                .setAllowedOriginPatterns("*")
                 .withSockJS();
     }
 }

--- a/src/main/java/com/capstone/skill_service/filter/UserContextFilter.java
+++ b/src/main/java/com/capstone/skill_service/filter/UserContextFilter.java
@@ -14,7 +14,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +35,11 @@ public class UserContextFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
+        if (path.startsWith("/ws")) { // allow websocket endpoints
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // fetch  user info from header
         String userId = request.getHeader("X-User-Id");
         String userEmail = request.getHeader("X-User-Email");

--- a/src/main/java/com/capstone/skill_service/messaging/CreateSkillErrorListenerEvent.java
+++ b/src/main/java/com/capstone/skill_service/messaging/CreateSkillErrorListenerEvent.java
@@ -1,0 +1,19 @@
+package com.capstone.skill_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.ErrorEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateSkillErrorListenerEvent {
+    private static final Logger logger = LoggerFactory.getLogger(CreateSkillErrorListenerEvent.class);
+
+    @RabbitListener(queues = "${SKILL_CREATE_ERROR_QUEUE}")
+    public void consumeErrorEvent(ErrorEvent errorEvent) {
+        logger.info("Consuming Error event: {}", errorEvent);
+    }
+}

--- a/src/main/java/com/capstone/skill_service/messaging/CreateSkillErrorListenerEvent.java
+++ b/src/main/java/com/capstone/skill_service/messaging/CreateSkillErrorListenerEvent.java
@@ -5,15 +5,19 @@ import org.common.event.ErrorEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class CreateSkillErrorListenerEvent {
     private static final Logger logger = LoggerFactory.getLogger(CreateSkillErrorListenerEvent.class);
-
+    private final SimpMessagingTemplate messagingTemplate;
     @RabbitListener(queues = "${SKILL_CREATE_ERROR_QUEUE}")
     public void consumeErrorEvent(ErrorEvent errorEvent) {
+        // send error message to the client
+        messagingTemplate.convertAndSend("/topic/errors", errorEvent);
+
         logger.info("Consuming Error event: {}", errorEvent);
     }
 }

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -133,7 +134,11 @@ public class CapsuleServiceImpl implements CapsuleService {
             atomNames.add(atom.getName());
         }
 
+        // pass userId to an event so to publish error to that specific user
+        String stringUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+
         CreateSkillEvent createSkillEvent = CreateSkillEvent.builder()
+                .userId(UUID.fromString(stringUserId))
                 .capsuleName(savedCapsule.getName())
                 .atoms(atomNames)
                 .build();


### PR DESCRIPTION
# 🚀 Pull Request: Handle internal communication Error.

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Handle internal communication Error.](https://amali-tech.atlassian.net/browse/VER-153)

---

## ✅ Summary

This PR implements the event exceptions that are raised during the internal communication when adding skill structure from Versapath to Moodle. Therefore, the skill service consumes the skill error event published by the LMS service and then sends the error message to the client via WebSocket.

---

## 📌 Features

- [x] Listen to the error event.
- [x] Configure websocket.
- [x] Display message instantly to the client.
