### PR TITLE
Publish events for skills CRUD operation

### DIFF
--- a/src/main/java/com/capstone/skill_service/config/RabbitMQConfig.java
+++ b/src/main/java/com/capstone/skill_service/config/RabbitMQConfig.java
@@ -19,6 +19,9 @@ public class RabbitMQConfig {
     @Value("${SKILL_ASSIGN_QUEUE}")
     private String skillAssignmentQueue;
 
+    @Value("${USER_UPDATE_QUEUE}")
+    private String userUpdateQueue;
+
     @Bean
     public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
         return new Jackson2JsonMessageConverter();
@@ -46,5 +49,11 @@ public class RabbitMQConfig {
     public Queue assignSkillQueue() {
         return new Queue(skillAssignmentQueue, true);
     }
+
+    @Bean
+    public Queue updateUserQueue() {
+        return new Queue(userUpdateQueue, true);
+    }
+
 
 }

--- a/src/main/java/com/capstone/skill_service/controller/RouteController.java
+++ b/src/main/java/com/capstone/skill_service/controller/RouteController.java
@@ -79,7 +79,7 @@ public class RouteController {
         this.routeService.deleteById(id);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
-                .message("Growth Route deleted successfully!")
+                .message("Talent Route deleted successfully!")
                 .errors(null)
                 .data(null)
                 .build();

--- a/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
+++ b/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
@@ -23,6 +23,12 @@ public class PopulateSkillEvents {
     @Value("${ATOM_CREATE_TOPIC}")
     private String atomCreateTopic;
 
+    @Value("${ATOM_UPDATE_TOPIC}")
+    private String atomUpdateTopic;
+
+    @Value("${ATOM_DELETE_TOPIC}")
+    private String atomDeleteTopic;
+
     @Value("${CAPSULE_CREATE_TOPIC}")
     private String capsuleCreateTopic;
 
@@ -36,6 +42,18 @@ public class PopulateSkillEvents {
         kafkaAtomTemplate.send(atomCreateTopic, atomEvent);
 
         logger.info("atom event is populated: {}", atomEvent);
+    }
+
+    public void populateUpdateAtom(SkillAtomEvent atomEvent){
+        kafkaAtomTemplate.send(atomUpdateTopic, atomEvent);
+
+        logger.info("atom event is populated for update: {}", atomEvent);
+    }
+
+    public void populateDeleteAtom(SkillAtomEvent atomEvent){
+        kafkaAtomTemplate.send(atomDeleteTopic, atomEvent);
+
+        logger.info("atom event is populated for delete: {}", atomEvent);
     }
 
     public void populateSkillCapsule(SkillCapsuleEvent capsuleEvent){

--- a/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
+++ b/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
@@ -44,6 +44,15 @@ public class PopulateSkillEvents {
     @Value("${GROWTH_TRACK_CREATE_TOPIC}")
     private String growthTrackCreateTopic;
 
+    @Value("${GROWTH_TRACK_UPDATE_TOPIC}")
+    private String growthTrackUpdateTopic;
+
+    @Value("${GROWTH_TRACK_DELETE_TOPIC}")
+    private String growthTrackDeleteTopic;
+
+    @Value("${GROWTH_TRACK_ASSIGN_TOPIC}")
+    private String growthTrackAssignTopic;
+
     @Value("${TALENT_ROUTE_CREATE_TOPIC}")
     private String talentRouteCreateTopic;
 
@@ -93,6 +102,24 @@ public class PopulateSkillEvents {
         kafkaGrowthTrackTemplate.send(growthTrackCreateTopic, growthTrackEvent);
 
         logger.info("growth track event is populated: {}", growthTrackEvent);
+    }
+
+    public void populateUpdateGrowthTrack(GrowthTrackEvent growthTrackEvent){
+        kafkaGrowthTrackTemplate.send(growthTrackUpdateTopic, growthTrackEvent);
+
+        logger.info("growthTrack event is populated for update: {}", growthTrackEvent);
+    }
+
+    public void populateDeleteGrowthTrack(GrowthTrackEvent growthTrackEvent){
+        kafkaGrowthTrackTemplate.send(growthTrackDeleteTopic, growthTrackEvent);
+
+        logger.info("growthTrack event is populated for delete: {}", growthTrackEvent);
+    }
+
+    public void populateAssignGrowthTrack(GrowthTrackEvent growthTrackEvent){
+        kafkaGrowthTrackTemplate.send(growthTrackAssignTopic, growthTrackEvent);
+
+        logger.info("growthTrack event is populated for capsule assignment: {}", growthTrackEvent);
     }
 
     public void populateTalentRoute(TalentRouteEvent talentRouteEvent){

--- a/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
+++ b/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
@@ -32,6 +32,15 @@ public class PopulateSkillEvents {
     @Value("${CAPSULE_CREATE_TOPIC}")
     private String capsuleCreateTopic;
 
+    @Value("${CAPSULE_UPDATE_TOPIC}")
+    private String capsuleUpdateTopic;
+
+    @Value("${CAPSULE_DELETE_TOPIC}")
+    private String capsuleDeleteTopic;
+
+    @Value("${CAPSULE_ASSIGN_TOPIC}")
+    private String capsuleAssignTopic;
+
     @Value("${GROWTH_TRACK_CREATE_TOPIC}")
     private String growthTrackCreateTopic;
 
@@ -60,6 +69,24 @@ public class PopulateSkillEvents {
         kafkaCapsuleTemplate.send(capsuleCreateTopic, capsuleEvent);
 
         logger.info("capsule event is populated: {}", capsuleEvent);
+    }
+
+    public void populateUpdateCapsule(SkillCapsuleEvent capsuleEvent){
+        kafkaCapsuleTemplate.send(capsuleUpdateTopic, capsuleEvent);
+
+        logger.info("capsule event is populated for update: {}", capsuleEvent);
+    }
+
+    public void populateDeleteCapsule(SkillCapsuleEvent capsuleEvent){
+        kafkaCapsuleTemplate.send(capsuleDeleteTopic, capsuleEvent);
+
+        logger.info("capsule event is populated for delete: {}", capsuleEvent);
+    }
+
+    public void populateAssignCapsule(SkillCapsuleEvent capsuleEvent){
+        kafkaCapsuleTemplate.send(capsuleAssignTopic, capsuleEvent);
+
+        logger.info("capsule event is populated for atom assignment: {}", capsuleEvent);
     }
 
     public void populateGrowthTrack(GrowthTrackEvent growthTrackEvent){

--- a/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
+++ b/src/main/java/com/capstone/skill_service/messaging/PopulateSkillEvents.java
@@ -56,6 +56,15 @@ public class PopulateSkillEvents {
     @Value("${TALENT_ROUTE_CREATE_TOPIC}")
     private String talentRouteCreateTopic;
 
+    @Value("${TALENT_ROUTE_UPDATE_TOPIC}")
+    private String talentRouteUpdateTopic;
+
+    @Value("${TALENT_ROUTE_DELETE_TOPIC}")
+    private String talentRouteDeleteTopic;
+
+    @Value("${TALENT_ROUTE_ASSIGN_TOPIC}")
+    private String talentRouteAssignTopic;
+
     public void populateSkillAtom(SkillAtomEvent atomEvent){
         kafkaAtomTemplate.send(atomCreateTopic, atomEvent);
 
@@ -126,6 +135,24 @@ public class PopulateSkillEvents {
         kafkaTalentRouteTemplate.send(talentRouteCreateTopic, talentRouteEvent);
 
         logger.info("talent route event is populated: {}", talentRouteEvent);
+    }
+
+    public void populateUpdateTalentRoute(TalentRouteEvent talentRouteEvent){
+        kafkaTalentRouteTemplate.send(talentRouteUpdateTopic, talentRouteEvent);
+
+        logger.info("talentRoute event is populated for update: {}", talentRouteEvent);
+    }
+
+    public void populateDeleteTalentRoute(TalentRouteEvent talentRouteEvent){
+        kafkaTalentRouteTemplate.send(talentRouteDeleteTopic, talentRouteEvent);
+
+        logger.info("talentRoute event is populated for delete: {}", talentRouteEvent);
+    }
+
+    public void populateAssignTalentRoute(TalentRouteEvent talentRouteEvent){
+        kafkaTalentRouteTemplate.send(talentRouteAssignTopic, talentRouteEvent);
+
+        logger.info("talentRoute event is populated for growth track assignment: {}", talentRouteEvent);
     }
 
 }

--- a/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
@@ -129,8 +129,6 @@ public class AtomServiceImpl implements AtomService {
         //populate event for deleting atom
         populateSkillEvents.populateDeleteAtom(SkillAtomEvent.builder()
                 .id(atom.getId())
-                .name(atom.getName())
-                .description(atom.getDescription())
                 .build());
 
         logger.info("Skill atom {} deleted", atom.getName());

--- a/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/AtomServiceImpl.java
@@ -115,7 +115,7 @@ public class AtomServiceImpl implements AtomService {
     @Caching(
         evict = {
             @CacheEvict(value = "atomList", allEntries = true), // to update the entire list
-            @CacheEvict(value = "atom", key = "#result.id") // evict single atom
+            @CacheEvict(value = "atom", key = "#id") // evict single atom
         }
     )
     public void deleteById(UUID id) {
@@ -125,6 +125,13 @@ public class AtomServiceImpl implements AtomService {
         // first delete all the reference
         List<CapsuleAtomMappingEntity> mappings = capsuleAtomMappingRepository.findBySkillAtomId(id);
         capsuleAtomMappingRepository.deleteAll(mappings);
+
+        //populate event for deleting atom
+        populateSkillEvents.populateDeleteAtom(SkillAtomEvent.builder()
+                .id(atom.getId())
+                .name(atom.getName())
+                .description(atom.getDescription())
+                .build());
 
         logger.info("Skill atom {} deleted", atom.getName());
 
@@ -165,9 +172,18 @@ public class AtomServiceImpl implements AtomService {
         }
         atom.setUpdatedAt(LocalDateTime.now());
 
+        SkillAtomEntity savedAtom = this.atomRepository.save(atom);
+
+        //populate event for updating atom
+        populateSkillEvents.populateUpdateAtom(SkillAtomEvent.builder()
+                .id(savedAtom.getId())
+                .name(savedAtom.getName())
+                .description(savedAtom.getDescription())
+                .build());
+
         logger.info("Skill atom {} updated", atom.getName());
 
-        return this.atomMapper.toDto(this.atomRepository.save(atom));
+        return this.atomMapper.toDto(savedAtom);
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -91,13 +91,13 @@ public class CapsuleServiceImpl implements CapsuleService {
 
         // send an event command
         sendEventToCreateSkillStructureOnMoodle(savedCapsule);
-        populateSkillCapsuleEvent(savedCapsule);
+        populateSkillCapsuleEvent(savedCapsule, "create");
 
         // map capsule to response dto
         return mapCapsuleToResponseDtoWithAtom(savedCapsule);
     }
 
-    void populateSkillCapsuleEvent(SkillCapsuleEntity capsuleEntity){
+    void populateSkillCapsuleEvent(SkillCapsuleEntity capsuleEntity, String type){
 
         List<Map<UUID, Integer>> listOfAtomsInCapsule = new ArrayList<>();
 
@@ -109,15 +109,27 @@ public class CapsuleServiceImpl implements CapsuleService {
             listOfAtomsInCapsule.add(atomWithSequenceOrder);
 
         }
+        if(type.equalsIgnoreCase("assignAtom")){
+            populateSkillEvents.populateAssignCapsule(SkillCapsuleEvent.builder()
+                    .id(capsuleEntity.getId())
+                    .name(capsuleEntity.getName())
+                    .description(capsuleEntity.getDescription())
+                    .difficulty(capsuleEntity.getDifficulty())
+                    .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
+                    .skillAtom(listOfAtomsInCapsule)
+                    .build());
+        }else{
+            populateSkillEvents.populateSkillCapsule(SkillCapsuleEvent.builder()
+                    .id(capsuleEntity.getId())
+                    .name(capsuleEntity.getName())
+                    .description(capsuleEntity.getDescription())
+                    .difficulty(capsuleEntity.getDifficulty())
+                    .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
+                    .skillAtom(listOfAtomsInCapsule)
+                    .build());
+        }
 
-        populateSkillEvents.populateSkillCapsule(SkillCapsuleEvent.builder()
-                        .id(capsuleEntity.getId())
-                        .name(capsuleEntity.getName())
-                        .description(capsuleEntity.getDescription())
-                        .difficulty(capsuleEntity.getDifficulty())
-                        .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
-                        .skillAtom(listOfAtomsInCapsule)
-                        .build());
+
 
     }
 
@@ -222,7 +234,12 @@ public class CapsuleServiceImpl implements CapsuleService {
     }
 
     @Override
-    @CacheEvict(value = "capsuleList", allEntries = true)
+    @Caching(
+        evict = {
+            @CacheEvict(value = "capsuleList", allEntries = true), // to update the entire list
+            @CacheEvict(value = "capsuleWithDetails", key = "#id") // evict single atom
+        }
+    )
     public void deleteById(UUID id) {
         SkillCapsuleEntity capsule = findById(id)
                 .orElseThrow( () -> new CapsuleNotFoundException("A Skill capsule provided doesn't exist")
@@ -230,6 +247,11 @@ public class CapsuleServiceImpl implements CapsuleService {
         // first delete all the reference
         List<TrackCapsuleMappingEntity> mappings = trackCapsuleMappingRepository.findBySkillCapsuleId(id);
         trackCapsuleMappingRepository.deleteAll(mappings);
+
+        // publish event to delete capsule
+        populateSkillEvents.populateDeleteCapsule(SkillCapsuleEvent.builder()
+                .id(capsule.getId())
+                .build());
 
         logger.info("Skill capsule {} deleted", capsule.getName());
 
@@ -370,6 +392,15 @@ public class CapsuleServiceImpl implements CapsuleService {
 
         SkillCapsuleEntity savedCapsule = capsuleRepository.save(capsule);
 
+        // publish event to update capsule
+        populateSkillEvents.populateUpdateCapsule(SkillCapsuleEvent.builder()
+                .id(savedCapsule.getId())
+                .name(savedCapsule.getName())
+                .description(savedCapsule.getDescription())
+                .difficulty(savedCapsule.getDifficulty())
+                .proficiencyLevel(savedCapsule.getProficiencyLevel().toString())
+                .build());
+
         // map capsule to response dto
         return mapCapsuleToResponseDtoWithAtom(savedCapsule);
     }
@@ -412,6 +443,9 @@ public class CapsuleServiceImpl implements CapsuleService {
         logger.info("Admin added new skill atoms to skill capsule: {}", capsuleEntity.getName());
 
         SkillCapsuleEntity savedCapsule = capsuleRepository.save(capsuleEntity);
+
+        // populate event to assign new atom to capsule
+        populateSkillCapsuleEvent(savedCapsule, "assignAtom");
 
         // map capsule to response dto
         return mapCapsuleToResponseDtoWithAtom(savedCapsule);

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -97,7 +97,7 @@ public class CapsuleServiceImpl implements CapsuleService {
         return mapCapsuleToResponseDtoWithAtom(savedCapsule);
     }
 
-    void populateSkillCapsuleEvent(SkillCapsuleEntity capsuleEntity, String type){
+    void populateSkillCapsuleEvent(SkillCapsuleEntity capsuleEntity, String eventType){
 
         List<Map<UUID, Integer>> listOfAtomsInCapsule = new ArrayList<>();
 
@@ -109,7 +109,22 @@ public class CapsuleServiceImpl implements CapsuleService {
             listOfAtomsInCapsule.add(atomWithSequenceOrder);
 
         }
-        if(type.equalsIgnoreCase("assignAtom")){
+
+        if(eventType.equalsIgnoreCase("delete")){
+            populateSkillEvents.populateDeleteCapsule(SkillCapsuleEvent.builder()
+                    .id(capsuleEntity.getId())
+                    .name(capsuleEntity.getName())
+                    .build());
+        }else if(eventType.equalsIgnoreCase("update")){
+            populateSkillEvents.populateUpdateCapsule(SkillCapsuleEvent.builder()
+                    .id(capsuleEntity.getId())
+                    .name(capsuleEntity.getName())
+                    .description(capsuleEntity.getDescription())
+                    .difficulty(capsuleEntity.getDifficulty())
+                    .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
+                    .skillAtom(listOfAtomsInCapsule)
+                    .build());
+        }else if(eventType.equalsIgnoreCase("assignAtom")){
             populateSkillEvents.populateAssignCapsule(SkillCapsuleEvent.builder()
                     .id(capsuleEntity.getId())
                     .name(capsuleEntity.getName())
@@ -118,7 +133,8 @@ public class CapsuleServiceImpl implements CapsuleService {
                     .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
                     .skillAtom(listOfAtomsInCapsule)
                     .build());
-        }else{
+        }
+        else{
             populateSkillEvents.populateSkillCapsule(SkillCapsuleEvent.builder()
                     .id(capsuleEntity.getId())
                     .name(capsuleEntity.getName())
@@ -128,8 +144,6 @@ public class CapsuleServiceImpl implements CapsuleService {
                     .skillAtom(listOfAtomsInCapsule)
                     .build());
         }
-
-
 
     }
 
@@ -249,9 +263,7 @@ public class CapsuleServiceImpl implements CapsuleService {
         trackCapsuleMappingRepository.deleteAll(mappings);
 
         // publish event to delete capsule
-        populateSkillEvents.populateDeleteCapsule(SkillCapsuleEvent.builder()
-                .id(capsule.getId())
-                .build());
+        populateSkillCapsuleEvent(capsule, "delete");
 
         logger.info("Skill capsule {} deleted", capsule.getName());
 
@@ -393,13 +405,7 @@ public class CapsuleServiceImpl implements CapsuleService {
         SkillCapsuleEntity savedCapsule = capsuleRepository.save(capsule);
 
         // publish event to update capsule
-        populateSkillEvents.populateUpdateCapsule(SkillCapsuleEvent.builder()
-                .id(savedCapsule.getId())
-                .name(savedCapsule.getName())
-                .description(savedCapsule.getDescription())
-                .difficulty(savedCapsule.getDifficulty())
-                .proficiencyLevel(savedCapsule.getProficiencyLevel().toString())
-                .build());
+        populateSkillCapsuleEvent(capsule, "update");
 
         // map capsule to response dto
         return mapCapsuleToResponseDtoWithAtom(savedCapsule);

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -405,7 +405,7 @@ public class CapsuleServiceImpl implements CapsuleService {
         SkillCapsuleEntity savedCapsule = capsuleRepository.save(capsule);
 
         // publish event to update capsule
-        populateSkillCapsuleEvent(capsule, "update");
+        populateSkillCapsuleEvent(savedCapsule, "update");
 
         // map capsule to response dto
         return mapCapsuleToResponseDtoWithAtom(savedCapsule);

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -76,14 +76,14 @@ public class RouteServiceImpl implements RouteService {
 
         logger.info("Admin created skill track: {}", routeEntity.getName());
 
-        //populate an event
-        populateTalentRouteEvent(savedTalentRoute);
+        //publish an event to create talent route
+        populateTalentRouteEvent(savedTalentRoute, "create");
 
         return this.routeMapper.toDto(savedTalentRoute);
 
     }
 
-    void populateTalentRouteEvent(TalentRouteEntity talentRoute){
+    void populateTalentRouteEvent(TalentRouteEntity talentRoute, String eventType){
         List<Map<UUID, Integer>> listOfTrackInTalentRoute = new ArrayList<>();
 
         for(RouteTrackMappingEntity mapping: talentRoute.getTracks()){
@@ -92,13 +92,33 @@ public class RouteServiceImpl implements RouteService {
 
             listOfTrackInTalentRoute.add(growthTrackWithSequenceOrder);
         }
-
-        populateSkillEvents.populateTalentRoute(TalentRouteEvent.builder()
-                .id(talentRoute.getId())
-                .name(talentRoute.getName())
-                .description(talentRoute.getDescription())
-                .growthTracks(listOfTrackInTalentRoute)
-                .build());
+        if(eventType.equalsIgnoreCase("delete")){
+            populateSkillEvents.populateDeleteTalentRoute(TalentRouteEvent.builder()
+                    .id(talentRoute.getId())
+                    .name(talentRoute.getName())
+                    .build());
+        }else if (eventType.equalsIgnoreCase("update")){
+            populateSkillEvents.populateUpdateTalentRoute(TalentRouteEvent.builder()
+                    .id(talentRoute.getId())
+                    .name(talentRoute.getName())
+                    .description(talentRoute.getDescription())
+                    .growthTracks(listOfTrackInTalentRoute)
+                    .build());
+        }else if (eventType.equalsIgnoreCase("assignGrowthTrack")){
+            populateSkillEvents.populateAssignTalentRoute(TalentRouteEvent.builder()
+                    .id(talentRoute.getId())
+                    .name(talentRoute.getName())
+                    .description(talentRoute.getDescription())
+                    .growthTracks(listOfTrackInTalentRoute)
+                    .build());
+        } else {
+            populateSkillEvents.populateTalentRoute(TalentRouteEvent.builder()
+                    .id(talentRoute.getId())
+                    .name(talentRoute.getName())
+                    .description(talentRoute.getDescription())
+                    .growthTracks(listOfTrackInTalentRoute)
+                    .build());
+        }
 
     }
 
@@ -274,6 +294,9 @@ public class RouteServiceImpl implements RouteService {
 
         logger.info("Talent route {} deleted", route.getName());
 
+        //publish an event to delete talent route
+        populateTalentRouteEvent(route, "delete");
+
         this.routeRepository.deleteById(id);
     }
 
@@ -320,9 +343,14 @@ public class RouteServiceImpl implements RouteService {
 
         route.setUpdatedAt(LocalDateTime.now());
 
+        TalentRouteEntity savedTalentRoute = this.routeRepository.save(route);
+
+        //publish an event to update talent route
+        populateTalentRouteEvent(savedTalentRoute, "update");
+
         logger.info("Talent route {} updated", route.getName());
 
-        return this.routeMapper.toDto(this.routeRepository.save(route));
+        return this.routeMapper.toDto(savedTalentRoute);
 
     }
 
@@ -358,6 +386,9 @@ public class RouteServiceImpl implements RouteService {
                 );
 
         addTrackToRoute(route, dto.getTrackIds()); // link route to all the growth track assigned to it
+
+        //publish an event to assign growth track to talent route
+        populateTalentRouteEvent(route, "assignGrowthTrack");
 
         logger.info("Admin added new growth track to talent route: {}", route.getName());
 

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -64,14 +64,14 @@ public class TrackServiceImpl implements TrackService {
         GrowthTrackEntity savedTrack = trackRepository.save(trackEntity);
         logger.info("Admin created skill track: {}", trackEntity.getName());
 
-        // populate an event
-        populateGrowthTrackEvent(savedTrack);
+        // populate an event to create growth track
+        populateGrowthTrackEvent(savedTrack, "create");
 
         return this.trackMapper.toDto(trackRepository.save(trackEntity));
 
     }
 
-    void populateGrowthTrackEvent(GrowthTrackEntity savedTrack){
+    void populateGrowthTrackEvent(GrowthTrackEntity savedTrack, String eventType){
         List<Map<UUID, Integer>> listOfCapsulesInGrowthTrack = new ArrayList<>();
 
         for(TrackCapsuleMappingEntity mapping: savedTrack.getSkillCapsules()){
@@ -81,12 +81,33 @@ public class TrackServiceImpl implements TrackService {
             listOfCapsulesInGrowthTrack.add(capsuleWithSequenceOrder);
         }
 
-        populateSkillEvents.populateGrowthTrack(GrowthTrackEvent.builder()
-                        .id(savedTrack.getId())
-                        .name(savedTrack.getName())
-                        .description(savedTrack.getDescription())
-                        .skillCapsules(listOfCapsulesInGrowthTrack)
-                        .build());
+        if(eventType.equalsIgnoreCase("delete")){
+            populateSkillEvents.populateDeleteGrowthTrack(GrowthTrackEvent.builder()
+                    .id(savedTrack.getId())
+                    .name(savedTrack.getName())
+                    .build());
+        } else if (eventType.equalsIgnoreCase("update")) {
+            populateSkillEvents.populateUpdateGrowthTrack(GrowthTrackEvent.builder()
+                    .id(savedTrack.getId())
+                    .name(savedTrack.getName())
+                    .description(savedTrack.getDescription())
+                    .skillCapsules(listOfCapsulesInGrowthTrack)
+                    .build());
+        } else if (eventType.equalsIgnoreCase("assignCapsule")) {
+            populateSkillEvents.populateAssignGrowthTrack(GrowthTrackEvent.builder()
+                    .id(savedTrack.getId())
+                    .name(savedTrack.getName())
+                    .description(savedTrack.getDescription())
+                    .skillCapsules(listOfCapsulesInGrowthTrack)
+                    .build());
+        } else{
+            populateSkillEvents.populateGrowthTrack(GrowthTrackEvent.builder()
+                    .id(savedTrack.getId())
+                    .name(savedTrack.getName())
+                    .description(savedTrack.getDescription())
+                    .skillCapsules(listOfCapsulesInGrowthTrack)
+                    .build());
+        }
 
     }
 
@@ -234,6 +255,9 @@ public class TrackServiceImpl implements TrackService {
         List<RouteTrackMappingEntity> mappings = routeTrackMappingRepository.findByTrackId(id);
         routeTrackMappingRepository.deleteAll(mappings);
 
+        // populate event to delete growth track
+        populateGrowthTrackEvent(track, "delete");
+
         logger.info("Growth track {} deleted", track.getName());
 
         this.trackRepository.deleteById(id);
@@ -281,9 +305,14 @@ public class TrackServiceImpl implements TrackService {
 
         track.setUpdatedAt(LocalDateTime.now());
 
+        GrowthTrackEntity savedTrack = this.trackRepository.save(track);
+
+        // populate event to update growth track
+        populateGrowthTrackEvent(savedTrack, "update");
+
         logger.info("Growth track {} updated", track.getName());
 
-        return this.trackMapper.toDto(this.trackRepository.save(track));
+        return this.trackMapper.toDto(savedTrack);
     }
 
     @Override
@@ -317,9 +346,13 @@ public class TrackServiceImpl implements TrackService {
 
         addCapsulesToTrack(track, dto.getCapsuleIds()); // link track to all the capsules assigned to it
 
+        GrowthTrackEntity savedTrack = trackRepository.save(track);
         logger.info("Admin added new skill capsule to growth track: {}", track.getName());
 
-        return this.trackMapper.toDto(trackRepository.save(track));
+        // publish event to assign new capsule
+        populateGrowthTrackEvent(savedTrack, "assignCapsule");
+
+        return this.trackMapper.toDto(savedTrack);
 
     }
 


### PR DESCRIPTION
# 🚀 Pull Request: Publish events for skills CRUD operation.

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-19: Publish events for skills CRUD operation .](https://amali-tech.atlassian.net/browse/VER-97)

---

## ✅ Summary

To maintain consistency of skills across all services that store snapshots, this PR publishes all events related to CRUD operations to keep those snapshots up-to-date.

---

## 📌 Features

- [x] Publish CRUD operation event for skill atom.
- [x] Publish CRUD operation event for skill capsule.
- [x] Publish CRUD operation event for growth track.
- [x] Publish CRUD operation event for talent route.
