### PR TITLE
Upload image for growth track and talent route

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>2.2.7</version>
+			<version>3.1.2</version>
 		</dependency>
 <!--		Kafka-->
 		<dependency>

--- a/src/main/java/com/capstone/skill_service/SkillServiceApplication.java
+++ b/src/main/java/com/capstone/skill_service/SkillServiceApplication.java
@@ -10,5 +10,4 @@ public class SkillServiceApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(SkillServiceApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/capstone/skill_service/controller/RouteController.java
+++ b/src/main/java/com/capstone/skill_service/controller/RouteController.java
@@ -15,10 +15,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 
@@ -29,13 +32,14 @@ import java.util.UUID;
 public class RouteController {
     private final RouteService routeService;
 
-    @PostMapping()
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('ADMIN')")
     @Operation(summary = "Create talent route", description = "This end point allows only admin to create a talent route")
     public ResponseEntity<ClientResponseFormatDto> createRoute(
-            @Valid @RequestBody RouteRequestDto routeRequestDto
-    ) {
-        RouteResponseDto savedRoute = this.routeService.create(routeRequestDto);
+            @Valid @RequestPart("talentRoute") RouteRequestDto routeRequestDto,
+            @RequestParam(value = "image", required = false) MultipartFile image
+    )throws IOException {
+        RouteResponseDto savedRoute = this.routeService.create(routeRequestDto, image);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Route created successfully!")
@@ -87,12 +91,13 @@ public class RouteController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PatchMapping("/{routeId}")
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('ADMIN')")
     @Operation(summary = "Update talent route", description = "This end point allows admin to update a talent route")
     public ResponseEntity<ClientResponseFormatDto> updateRoute(
-            @Valid @RequestBody RouteUpdateRequestDto routeRequestDto, @PathVariable UUID routeId) {
-        RouteResponseDto updatedRoute = this.routeService.partialUpdate(routeRequestDto, routeId);
+            @Valid @RequestPart("talentRoute") RouteUpdateRequestDto routeRequestDto,
+            @RequestParam(value = "image", required = false) MultipartFile image) throws IOException{
+        RouteResponseDto updatedRoute = this.routeService.partialUpdate(routeRequestDto, image);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Talent route updated successfully!")

--- a/src/main/java/com/capstone/skill_service/controller/TrackController.java
+++ b/src/main/java/com/capstone/skill_service/controller/TrackController.java
@@ -12,10 +12,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 
@@ -26,13 +29,14 @@ import java.util.UUID;
 public class TrackController {
     private final TrackService trackService;
 
-    @PostMapping()
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('ADMIN')")
     @Operation(summary = "Create growth track", description = "This end point allows only admin to create a growth track")
     public ResponseEntity<ClientResponseFormatDto> createTrack(
-            @Valid @RequestBody TrackRequestDto trackRequestDto
-    ) {
-        TrackResponseDto savedTrack = this.trackService.create(trackRequestDto);
+            @Valid @RequestPart("growthTrack") TrackRequestDto trackRequestDto,
+            @RequestParam(value = "image", required = false) MultipartFile image
+    )throws IOException {
+        TrackResponseDto savedTrack = this.trackService.create(trackRequestDto, image);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Track created successfully!")
@@ -84,12 +88,13 @@ public class TrackController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PatchMapping("/{trackId}")
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('ADMIN')")
     @Operation(summary = "Update growth track", description = "This end point allows admin to update a growth track")
     public ResponseEntity<ClientResponseFormatDto> updateTrack(
-            @Valid @RequestBody TrackUpdateRequestDto trackRequestDto, @PathVariable UUID trackId) {
-        TrackResponseDto updatedTrack = this.trackService.partialUpdate(trackRequestDto, trackId);
+            @Valid @RequestPart("growthTrack") TrackUpdateRequestDto trackRequestDto,
+            @RequestParam(value = "image", required = false) MultipartFile image) throws IOException{
+        TrackResponseDto updatedTrack = this.trackService.partialUpdate(trackRequestDto, image);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Growth Track updated successfully!")

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteResponseDto.java
@@ -1,6 +1,5 @@
 package com.capstone.skill_service.dto.route;
 
-import com.capstone.skill_service.dto.capsule.CapsuleSummaryResponseDto;
 import com.capstone.skill_service.dto.track.TrackSummaryResponseDto;
 import com.capstone.skill_service.util.Status;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -28,6 +27,7 @@ public class RouteResponseDto implements Serializable {
     private String roleName;
     private String description;
     private Status status;
+    private String image;
     private List<TrackSummaryResponseDto> tracks;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteUpdateRequestDto.java
@@ -26,6 +26,8 @@ public class RouteUpdateRequestDto {
     @Pattern(regexp = "^[A-Za-z ]+$", message = "Role name cannot contain numbers")
     private String roleName;
 
+    private UUID talentRouteId;
+
     List<UUID> growthTrackIds; // list of growth track ids
     private String description;
     private Status status;

--- a/src/main/java/com/capstone/skill_service/dto/route/RouteWithTrackResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/route/RouteWithTrackResponseDto.java
@@ -27,6 +27,7 @@ public class RouteWithTrackResponseDto implements Serializable {
     private String roleName;
     private String description;
     private Status status;
+    private String image;
     private List<TrackInSequenceOrderResponseDto> tracks;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackOnlyResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackOnlyResponseDto.java
@@ -21,17 +21,20 @@ public class TrackOnlyResponseDto implements Serializable {
     private String description;
     private int estimatedMonths;
     private Status status;
+    private String image;
     private long capsuleNumber;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+
     public TrackOnlyResponseDto(UUID id, String name, String description, int estimatedMonths, Status status,
-                                long capsuleNumber, LocalDateTime createdAt, LocalDateTime updatedAt) {
+                                String image, long capsuleNumber, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.estimatedMonths = estimatedMonths;
         this.status = status;
+        this.image = image;
         this.capsuleNumber = capsuleNumber;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackResponseDto.java
@@ -27,6 +27,7 @@ public class TrackResponseDto implements Serializable {
     private String description;
     private int estimatedMonths;
     private Status status;
+    private String image;
     private List<CapsuleSummaryResponseDto> capsules;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackUpdateRequestDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackUpdateRequestDto.java
@@ -19,8 +19,9 @@ public class TrackUpdateRequestDto {
     @Size(min = 3, message = "Name must have at least 3 characters")
     @Pattern(regexp = "^[A-Za-z ]+$", message = "name cannot contain numbers")
     private String name;
-    private int estimatedMonths;
 
+    private UUID trackId;
+    private int estimatedMonths;
     List<UUID> capsuleIds; // list of capsule ids
     private String description;
     private Status status;

--- a/src/main/java/com/capstone/skill_service/dto/track/TrackWithCapsuleResponseDto.java
+++ b/src/main/java/com/capstone/skill_service/dto/track/TrackWithCapsuleResponseDto.java
@@ -27,6 +27,7 @@ public class TrackWithCapsuleResponseDto implements Serializable {
     private String description;
     private int estimatedMonths;
     private Status status;
+    private String image;
     private List<CapsuleInSequenceOrderResponseDto> capsules;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/RouteMapper.java
@@ -15,6 +15,7 @@ public interface RouteMapper {
     RouteResponseDto toDto(TalentRouteEntity entity);
 
     TalentRouteEntity toEntity(RouteRequestDto dto);
+    TalentRouteEntity toEntity(RouteResponseDto dto);
     @Mapping(target = "tracks",  source = "tracks")
     RouteWithTrackResponseDto toWithTrackDto(TalentRouteEntity entity);
 

--- a/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
+++ b/src/main/java/com/capstone/skill_service/mapper/TrackMapper.java
@@ -16,6 +16,7 @@ public interface TrackMapper {
     TrackOnlyResponseDto toOnlyTrackDto(GrowthTrackEntity entity);
 
     GrowthTrackEntity toEntity(TrackRequestDto dto);
+    GrowthTrackEntity toEntity(TrackOnlyResponseDto dto);
     @Mapping(target = "capsules",  source = "skillCapsules")
     TrackWithCapsuleResponseDto toWithCapsuleDto(GrowthTrackEntity entity);
 

--- a/src/main/java/com/capstone/skill_service/model/GrowthTrackEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/GrowthTrackEntity.java
@@ -37,7 +37,7 @@ public class GrowthTrackEntity {
     private List<TrackCapsuleMappingEntity> skillCapsules = new ArrayList<>();
 
     private int estimatedMonths;
-
+    private String image;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/capstone/skill_service/model/TalentRouteEntity.java
+++ b/src/main/java/com/capstone/skill_service/model/TalentRouteEntity.java
@@ -35,6 +35,8 @@ public class TalentRouteEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    private String image;
+
     @OneToMany(mappedBy = "talentRoute", cascade = CascadeType.ALL, orphanRemoval = true) // just remove child from talent route list
     @OrderBy("sequenceOrder ASC") // to always display growth track in sequence order
     private List<RouteTrackMappingEntity> tracks = new ArrayList<>();

--- a/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
@@ -1,9 +1,7 @@
 package com.capstone.skill_service.repository;
 
-import com.capstone.skill_service.dto.capsule.CapsuleWithAtomCountResponseDto;
 import com.capstone.skill_service.dto.track.TrackOnlyResponseDto;
 import com.capstone.skill_service.model.GrowthTrackEntity;
-import com.capstone.skill_service.model.SkillCapsuleEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,7 +28,7 @@ public interface TrackRepository extends JpaRepository<GrowthTrackEntity, UUID> 
 
     @Query("""
     SELECT new com.capstone.skill_service.dto.track.TrackOnlyResponseDto(
-        t.id,t.name,t.description,t.estimatedMonths,t.status,(SELECT COUNT(mc.growthTrack.id) FROM t.skillCapsules mc),
+        t.id,t.name,t.description,t.estimatedMonths,t.status,t.image,(SELECT COUNT(mc.growthTrack.id) FROM t.skillCapsules mc),
         t.createdAt,t.updatedAt)
     FROM GrowthTrackEntity t
     """)

--- a/src/main/java/com/capstone/skill_service/service/RouteService.java
+++ b/src/main/java/com/capstone/skill_service/service/RouteService.java
@@ -9,13 +9,15 @@ import com.capstone.skill_service.dto.track.*;
 import com.capstone.skill_service.model.TalentRouteEntity;
 import com.capstone.skill_service.util.Status;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface RouteService {
-    RouteResponseDto create(RouteRequestDto dto);
+    RouteResponseDto create(RouteRequestDto dto, MultipartFile image) throws IOException;
     Optional<TalentRouteEntity> findByName(String name);
     Optional<TalentRouteEntity> findByRoleName(String roleName);
     Optional<TalentRouteEntity> findById(UUID id);
@@ -23,7 +25,7 @@ public interface RouteService {
     RouteResponseDto getRoute(UUID id);
     RouteWithTrackResponseDto getRouteWithTracks(UUID routeId);
     void deleteById(UUID id);
-    RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, UUID id);
+    RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, MultipartFile image) throws IOException;
     RouteResponseDto updateStatus(Status status, UUID id);
     RouteResponseDto assignTrackToRoute(UUID routeId, TrackIdsRequestDto dto);
     void removeTrackFromRoute(UUID routeId, UUID trackId);

--- a/src/main/java/com/capstone/skill_service/service/TrackService.java
+++ b/src/main/java/com/capstone/skill_service/service/TrackService.java
@@ -6,20 +6,22 @@ import com.capstone.skill_service.dto.track.*;
 import com.capstone.skill_service.model.GrowthTrackEntity;
 import com.capstone.skill_service.util.Status;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface TrackService {
-    TrackResponseDto create(TrackRequestDto dto);
+    TrackResponseDto create(TrackRequestDto dto, MultipartFile image) throws IOException;
     Optional<GrowthTrackEntity> findByName(String name);
     Optional<GrowthTrackEntity> findById(UUID id);
     CustomPageResponse<TrackOnlyResponseDto> findAll(Pageable pageable);
     TrackResponseDto getTrack(UUID id);
     TrackWithCapsuleResponseDto getTrackWithCapsules(UUID trackId);
     void deleteById(UUID id);
-    TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id);
+    TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, MultipartFile image) throws IOException;
     TrackResponseDto updateStatus(Status status, UUID id);
     TrackResponseDto assignCapsuleToTrack(UUID trackId, CapsuleIdsRequestDto dto);
     void removeCapsuleFromTrack(UUID trackId, UUID capsuleId);

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -17,7 +17,10 @@ import com.capstone.skill_service.mapper.TrackMapper;
 import com.capstone.skill_service.messaging.PopulateSkillEvents;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
+import com.capstone.skill_service.service.AwsFileUploadService;
+import com.capstone.skill_service.service.PreSignedUrlService;
 import com.capstone.skill_service.service.RouteService;
+import com.capstone.skill_service.util.FileHelper;
 import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
 import org.common.event.TalentRouteEvent;
@@ -29,7 +32,9 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -47,11 +52,13 @@ public class RouteServiceImpl implements RouteService {
     private final AtomMapper atomMapper;
     private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
     private final PopulateSkillEvents populateSkillEvents;
+    private final AwsFileUploadService awsFileUploadService;
+    private final PreSignedUrlService preSignedUrlService;
 
 
     @Override
     @CacheEvict(value = "talentRouteList",  allEntries = true)
-    public RouteResponseDto create(RouteRequestDto dto) {
+    public RouteResponseDto create(RouteRequestDto dto, MultipartFile image) throws IOException {
         if(findByName(dto.getName()).isPresent()){
             throw new RouteExistsException(
                     String.format("A talent route with the name '%s' already exist",
@@ -69,18 +76,24 @@ public class RouteServiceImpl implements RouteService {
         if(dto.getStatus() == null){ // set default value
             routeEntity.setStatus(Status.ACTIVE);
         }
+        if(image != null){
+            FileHelper.validateImage(image); // validate image
+            routeEntity.setImage(awsFileUploadService.uploadFile(image)); //upload image
+        }
 
         addTrackToRoute(routeEntity, dto.getTrackIds()); // link talent route to all the talent route assigned to
 
         TalentRouteEntity savedTalentRoute = routeRepository.save(routeEntity);
-
-        logger.info("Admin created skill track: {}", routeEntity.getName());
+        RouteResponseDto response = this.routeMapper.toDto(savedTalentRoute);
 
         //publish an event to create talent route
         populateTalentRouteEvent(savedTalentRoute, "create");
 
-        return this.routeMapper.toDto(savedTalentRoute);
+        logger.info("Admin created skill track: {}", routeEntity.getName());
 
+        FileHelper.generatePresignedUrl(savedTalentRoute, response, preSignedUrlService);
+
+        return response;
     }
 
     void populateTalentRouteEvent(TalentRouteEntity talentRoute, String eventType){
@@ -101,6 +114,7 @@ public class RouteServiceImpl implements RouteService {
             populateSkillEvents.populateUpdateTalentRoute(TalentRouteEvent.builder()
                     .id(talentRoute.getId())
                     .name(talentRoute.getName())
+                    .image(talentRoute.getImage())
                     .description(talentRoute.getDescription())
                     .growthTracks(listOfTrackInTalentRoute)
                     .build());
@@ -108,6 +122,7 @@ public class RouteServiceImpl implements RouteService {
             populateSkillEvents.populateAssignTalentRoute(TalentRouteEvent.builder()
                     .id(talentRoute.getId())
                     .name(talentRoute.getName())
+                    .image(talentRoute.getImage())
                     .description(talentRoute.getDescription())
                     .growthTracks(listOfTrackInTalentRoute)
                     .build());
@@ -115,6 +130,7 @@ public class RouteServiceImpl implements RouteService {
             populateSkillEvents.populateTalentRoute(TalentRouteEvent.builder()
                     .id(talentRoute.getId())
                     .name(talentRoute.getName())
+                    .image(talentRoute.getImage())
                     .description(talentRoute.getDescription())
                     .growthTracks(listOfTrackInTalentRoute)
                     .build());
@@ -178,6 +194,13 @@ public class RouteServiceImpl implements RouteService {
         Page<TalentRouteEntity> routeList = this.routeRepository.findAllWithGrowthTrack(pageable);
         Page<RouteResponseDto> routes = routeList.map(this.routeMapper::toDto);
 
+        for(RouteResponseDto route: routes){
+            // generate presigned url
+            String imageUrl = FileHelper.getGeneratedPresignedUrl(this.routeMapper.toEntity(route),
+                    preSignedUrlService);
+            route.setImage(imageUrl);
+        }
+
         logger.info("Talent route list is fetched");
 
         return CustomPageResponse.<RouteResponseDto>builder()
@@ -210,6 +233,11 @@ public class RouteServiceImpl implements RouteService {
     public RouteWithTrackResponseDto getRouteWithTracks(UUID routeId) {
         TalentRouteEntity route = routeRepository.findByIdWithGrowthTracks(routeId)
                 .orElseThrow(() -> new RouteNotFoundException("A Talent Route not found"));
+
+        // generate presigned url
+        String imageUrl = FileHelper.getGeneratedPresignedUrl(route,
+                preSignedUrlService);
+        route.setImage(imageUrl);
 
         // get mappings (growth track and sequence order)
         List<RouteTrackMappingEntity> mappings = route.getTracks();
@@ -304,11 +332,11 @@ public class RouteServiceImpl implements RouteService {
     @Caching(
         evict = {
             @CacheEvict(value = "talentRouteList", allEntries = true), // to update the entire list
-            @CacheEvict(value = "talentRoute", key = "#id") // evict single talent route
+            @CacheEvict(value = "talentRoute", key = "#dto.getTalentRouteId()") // evict single talent route
         }
     )
-    public RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, UUID id) {
-        TalentRouteEntity route = findById(id)
+    public RouteResponseDto partialUpdate(RouteUpdateRequestDto dto, MultipartFile image) throws IOException {
+        TalentRouteEntity route = findById(dto.getTalentRouteId())
                 .orElseThrow( () -> new RouteNotFoundException("A talent route provided doesn't exist")
                 );
         if(dto.getName() != null){
@@ -340,17 +368,24 @@ public class RouteServiceImpl implements RouteService {
         if(dto.getGrowthTrackIds() != null){
             addTrackToRoute(route, dto.getGrowthTrackIds());
         }
+        if(image != null){
+            FileHelper.validateImage(image); // validate image
+            route.setImage(awsFileUploadService.uploadFile(image)); //upload image
+        }
 
         route.setUpdatedAt(LocalDateTime.now());
 
         TalentRouteEntity savedTalentRoute = this.routeRepository.save(route);
+        RouteResponseDto response = this.routeMapper.toDto(savedTalentRoute);
 
         //publish an event to update talent route
         populateTalentRouteEvent(savedTalentRoute, "update");
 
+        FileHelper.generatePresignedUrl(savedTalentRoute, response, preSignedUrlService);
+
         logger.info("Talent route {} updated", route.getName());
 
-        return this.routeMapper.toDto(savedTalentRoute);
+        return response;
 
     }
 

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -73,12 +73,13 @@ public class TrackServiceImpl implements TrackService {
 
         GrowthTrackEntity savedTrack = trackRepository.save(trackEntity);
         TrackResponseDto response = this.trackMapper.toDto(savedTrack);
-        logger.info("Admin created skill track: {}", trackEntity.getName());
-
-        FileHelper.generatePresignedUrl(savedTrack, response, preSignedUrlService);
 
         // populate an event to create growth track
         populateGrowthTrackEvent(savedTrack, "create");
+
+        logger.info("Admin created skill track: {}", trackEntity.getName());
+
+        FileHelper.generatePresignedUrl(savedTrack, response, preSignedUrlService);
 
         return response;
 
@@ -103,6 +104,7 @@ public class TrackServiceImpl implements TrackService {
             populateSkillEvents.populateUpdateGrowthTrack(GrowthTrackEvent.builder()
                     .id(savedTrack.getId())
                     .name(savedTrack.getName())
+                    .image(savedTrack.getImage())
                     .description(savedTrack.getDescription())
                     .skillCapsules(listOfCapsulesInGrowthTrack)
                     .build());
@@ -110,6 +112,7 @@ public class TrackServiceImpl implements TrackService {
             populateSkillEvents.populateAssignGrowthTrack(GrowthTrackEvent.builder()
                     .id(savedTrack.getId())
                     .name(savedTrack.getName())
+                    .image(savedTrack.getImage())
                     .description(savedTrack.getDescription())
                     .skillCapsules(listOfCapsulesInGrowthTrack)
                     .build());
@@ -117,6 +120,7 @@ public class TrackServiceImpl implements TrackService {
             populateSkillEvents.populateGrowthTrack(GrowthTrackEvent.builder()
                     .id(savedTrack.getId())
                     .name(savedTrack.getName())
+                    .image(savedTrack.getImage())
                     .description(savedTrack.getDescription())
                     .skillCapsules(listOfCapsulesInGrowthTrack)
                     .build());
@@ -173,6 +177,13 @@ public class TrackServiceImpl implements TrackService {
     public CustomPageResponse<TrackOnlyResponseDto> findAll(Pageable pageable) {
         Page<TrackOnlyResponseDto> growthTracks = this.trackRepository.findTrackWithCapsuleCount(pageable);
 
+        for(TrackOnlyResponseDto growthTrack: growthTracks){
+            // generate presigned url
+            String imageUrl = FileHelper.getGeneratedPresignedUrl(this.trackMapper.toEntity(growthTrack),
+                    preSignedUrlService);
+            growthTrack.setImage(imageUrl);
+        }
+
         logger.info("Growth tracks list is fetched");
 
         return CustomPageResponse.<TrackOnlyResponseDto>builder()
@@ -193,6 +204,11 @@ public class TrackServiceImpl implements TrackService {
     public TrackWithCapsuleResponseDto getTrackWithCapsules(UUID trackId) {
         GrowthTrackEntity track = trackRepository.findByIdWithCapsules(trackId)
                 .orElseThrow(() -> new TrackNotFoundException("A Growth Track not found"));
+
+        // generate presigned url
+        String imageUrl = FileHelper.getGeneratedPresignedUrl(track,
+                preSignedUrlService);
+        track.setImage(imageUrl);
 
         // get mappings (capsule and sequence order)
         List<TrackCapsuleMappingEntity> mappings = track.getSkillCapsules();

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -13,7 +13,10 @@ import com.capstone.skill_service.mapper.TrackMapper;
 import com.capstone.skill_service.messaging.PopulateSkillEvents;
 import com.capstone.skill_service.model.*;
 import com.capstone.skill_service.repository.*;
+import com.capstone.skill_service.service.AwsFileUploadService;
+import com.capstone.skill_service.service.PreSignedUrlService;
 import com.capstone.skill_service.service.TrackService;
+import com.capstone.skill_service.util.FileHelper;
 import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
 import org.common.event.GrowthTrackEvent;
@@ -25,7 +28,9 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -42,10 +47,12 @@ public class TrackServiceImpl implements TrackService {
     private final RouteTrackMappingRepository routeTrackMappingRepository;
     private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
     private final PopulateSkillEvents populateSkillEvents;
+    private final AwsFileUploadService awsFileUploadService;
+    private final PreSignedUrlService preSignedUrlService;
 
     @Override
     @CacheEvict(value = "growthTrackList",  allEntries = true)
-    public TrackResponseDto create(TrackRequestDto dto) {
+    public TrackResponseDto create(TrackRequestDto dto, MultipartFile image) throws IOException {
         if(findByName(dto.getName()).isPresent()){
             throw new TrackExistsException(
                     String.format("A Growth Track with the name '%s' already exist",
@@ -58,16 +65,22 @@ public class TrackServiceImpl implements TrackService {
         if(dto.getStatus() == null){ // set default value
             trackEntity.setStatus(Status.ACTIVE);
         }
+        if(image != null){
+            FileHelper.validateImage(image); // validate image
+            trackEntity.setImage(awsFileUploadService.uploadFile(image)); //upload image
+        }
         addCapsulesToTrack(trackEntity, dto.getCapsuleIds()); // link track to all the capsules assigned to
 
-
         GrowthTrackEntity savedTrack = trackRepository.save(trackEntity);
+        TrackResponseDto response = this.trackMapper.toDto(savedTrack);
         logger.info("Admin created skill track: {}", trackEntity.getName());
+
+        FileHelper.generatePresignedUrl(savedTrack, response, preSignedUrlService);
 
         // populate an event to create growth track
         populateGrowthTrackEvent(savedTrack, "create");
 
-        return this.trackMapper.toDto(trackRepository.save(trackEntity));
+        return response;
 
     }
 
@@ -267,11 +280,11 @@ public class TrackServiceImpl implements TrackService {
     @Caching(
         evict = {
             @CacheEvict(value = "growthTrackList", allEntries = true), // to update the entire list
-            @CacheEvict(value = "track", key = "#id") // evict single track
+            @CacheEvict(value = "track", key = "#dto.getTrackId()") // evict single track
         }
     )
-    public TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, UUID id) {
-        GrowthTrackEntity track = findById(id)
+    public TrackResponseDto partialUpdate(TrackUpdateRequestDto dto, MultipartFile image) throws IOException {
+        GrowthTrackEntity track = findById(dto.getTrackId())
                 .orElseThrow( () -> new TrackNotFoundException("A growth track provided doesn't exist")
                 );
         if(dto.getName() != null){
@@ -302,17 +315,24 @@ public class TrackServiceImpl implements TrackService {
         if(dto.getCapsuleIds() != null){
             addCapsulesToTrack(track, dto.getCapsuleIds());
         }
+        if(image != null){
+            FileHelper.validateImage(image); // validate image
+            track.setImage(awsFileUploadService.uploadFile(image)); //upload image
+        }
 
         track.setUpdatedAt(LocalDateTime.now());
 
         GrowthTrackEntity savedTrack = this.trackRepository.save(track);
+        TrackResponseDto response = this.trackMapper.toDto(savedTrack);
 
         // populate event to update growth track
         populateGrowthTrackEvent(savedTrack, "update");
 
+        FileHelper.generatePresignedUrl(savedTrack, response, preSignedUrlService);
+
         logger.info("Growth track {} updated", track.getName());
 
-        return this.trackMapper.toDto(savedTrack);
+        return response;
     }
 
     @Override

--- a/src/main/java/com/capstone/skill_service/util/FileHelper.java
+++ b/src/main/java/com/capstone/skill_service/util/FileHelper.java
@@ -2,8 +2,10 @@ package com.capstone.skill_service.util;
 
 import com.capstone.skill_service.dto.capsule.CapsuleResponseDto;
 import com.capstone.skill_service.dto.cluster.ClusterResponseDto;
+import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.exception.FileException;
 import com.capstone.skill_service.model.ClusterEntity;
+import com.capstone.skill_service.model.GrowthTrackEntity;
 import com.capstone.skill_service.model.SkillCapsuleEntity;
 import com.capstone.skill_service.service.PreSignedUrlService;
 import org.springframework.util.unit.DataSize;
@@ -45,6 +47,15 @@ public class FileHelper {
         if (savedCluster.getImageName() != null) {
             String presignedUrl = preSignedUrlService.generatePresignedUrl(savedCluster.getImageName());
             responseDto.setImageName(presignedUrl);
+        }
+    }
+
+    public static void generatePresignedUrl(GrowthTrackEntity savedTrack,
+                                            TrackResponseDto responseDto,
+                                            PreSignedUrlService preSignedUrlService ){
+        if (savedTrack.getImage() != null) {
+            String presignedUrl = preSignedUrlService.generatePresignedUrl(savedTrack.getImage());
+            responseDto.setImage(presignedUrl);
         }
     }
 

--- a/src/main/java/com/capstone/skill_service/util/FileHelper.java
+++ b/src/main/java/com/capstone/skill_service/util/FileHelper.java
@@ -2,11 +2,13 @@ package com.capstone.skill_service.util;
 
 import com.capstone.skill_service.dto.capsule.CapsuleResponseDto;
 import com.capstone.skill_service.dto.cluster.ClusterResponseDto;
+import com.capstone.skill_service.dto.route.RouteResponseDto;
 import com.capstone.skill_service.dto.track.TrackResponseDto;
 import com.capstone.skill_service.exception.FileException;
 import com.capstone.skill_service.model.ClusterEntity;
 import com.capstone.skill_service.model.GrowthTrackEntity;
 import com.capstone.skill_service.model.SkillCapsuleEntity;
+import com.capstone.skill_service.model.TalentRouteEntity;
 import com.capstone.skill_service.service.PreSignedUrlService;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartFile;
@@ -59,6 +61,15 @@ public class FileHelper {
         }
     }
 
+    public static void generatePresignedUrl(TalentRouteEntity savedTalentRoute,
+                                            RouteResponseDto responseDto,
+                                            PreSignedUrlService preSignedUrlService ){
+        if (savedTalentRoute.getImage() != null) {
+            String presignedUrl = preSignedUrlService.generatePresignedUrl(savedTalentRoute.getImage());
+            responseDto.setImage(presignedUrl);
+        }
+    }
+
     public static String getGeneratedPresignedUrl(ClusterEntity savedCluster,
                                             PreSignedUrlService preSignedUrlService ){
         if (savedCluster.getImageName() != null) {
@@ -71,6 +82,22 @@ public class FileHelper {
                                             PreSignedUrlService preSignedUrlService ){
         if (savedCapsule.getImage() != null) {
             return preSignedUrlService.generatePresignedUrl(savedCapsule.getImage());
+        }
+        return null;
+    }
+
+    public static String getGeneratedPresignedUrl(TalentRouteEntity savedTalentRoute,
+                                                  PreSignedUrlService preSignedUrlService ){
+        if (savedTalentRoute.getImage() != null) {
+            return preSignedUrlService.generatePresignedUrl(savedTalentRoute.getImage());
+        }
+        return null;
+    }
+
+    public static String getGeneratedPresignedUrl(GrowthTrackEntity savedTrack,
+                                                  PreSignedUrlService preSignedUrlService ){
+        if (savedTrack.getImage() != null) {
+            return preSignedUrlService.generatePresignedUrl(savedTrack.getImage());
         }
         return null;
     }


### PR DESCRIPTION
# 🚀 PR: Upload image for growth track and talent route

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Skill taxonomy management.](https://amali-tech.atlassian.net/browse/VER-19)

---

## ✅ Summary

This PR adds some new functionalities and updates based on the frontend team's request.

---

## 📌 Features

- [x] Upload and display image for talent routes
- [x] Upload and display image for growth track
- [x] Update event payload with image field 

## 🚧 Next Task

- Filter growth track and talent route by name.
