### PR TITLE
Filter growth track and talent route by name

### DIFF
--- a/src/main/java/com/capstone/skill_service/controller/RouteController.java
+++ b/src/main/java/com/capstone/skill_service/controller/RouteController.java
@@ -7,13 +7,16 @@ import com.capstone.skill_service.dto.route.RouteResponseDto;
 import com.capstone.skill_service.dto.route.RouteUpdateRequestDto;
 import com.capstone.skill_service.dto.route.RouteWithTrackResponseDto;
 import com.capstone.skill_service.dto.track.TrackIdsRequestDto;
+import com.capstone.skill_service.dto.track.TrackOnlyResponseDto;
 import com.capstone.skill_service.service.RouteService;
 import com.capstone.skill_service.util.Status;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -164,6 +167,25 @@ public class RouteController {
                 .message("Tracks reordered in route successfully!")
                 .errors(null)
                 .data(Map.of("item", updatedRoute))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+
+    @GetMapping("/filter")
+    @Operation(summary = "Filter talent route", description = "This end point allows user to filter talent route list")
+    public ResponseEntity<ClientResponseFormatDto> filterGrowthTracks(
+            @RequestParam(required = false) String name,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "${PAGE_SIZE}") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        CustomPageResponse<RouteResponseDto> tracks = this.routeService.filterByName(name, pageable);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Filter talent routes")
+                .errors(null)
+                .data(tracks)
                 .build();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/capstone/skill_service/controller/TrackController.java
+++ b/src/main/java/com/capstone/skill_service/controller/TrackController.java
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -165,4 +167,21 @@ public class TrackController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @GetMapping("/filter")
+    @Operation(summary = "Filter growth track", description = "This end point allows user to filter growth track list")
+    public ResponseEntity<ClientResponseFormatDto> filterGrowthTracks(
+            @RequestParam(required = false) String name,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "${PAGE_SIZE}") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        CustomPageResponse<TrackOnlyResponseDto> tracks = this.trackService.filterByName(name, pageable);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Filter growth tracks")
+                .errors(null)
+                .data(tracks)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/src/main/java/com/capstone/skill_service/repository/RouteRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/RouteRepository.java
@@ -31,4 +31,12 @@ public interface RouteRepository extends JpaRepository<TalentRouteEntity, UUID> 
         ORDER BY tr.createdAt DESC
     """)
     Page<TalentRouteEntity> findAllWithGrowthTrack(Pageable pageable);
+
+    @Query("""
+        SELECT tr FROM TalentRouteEntity tr
+        LEFT JOIN FETCH tr.tracks c
+        WHERE (:name IS NULL OR LOWER(tr.name) LIKE LOWER(CONCAT('%', :name, '%')))
+        ORDER BY tr.createdAt DESC
+    """)
+    Page<TalentRouteEntity> filterByNameContainingIgnoreCase(@Param("name") String name, Pageable pageable);
 }

--- a/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
+++ b/src/main/java/com/capstone/skill_service/repository/TrackRepository.java
@@ -34,4 +34,14 @@ public interface TrackRepository extends JpaRepository<GrowthTrackEntity, UUID> 
     """)
     Page<TrackOnlyResponseDto> findTrackWithCapsuleCount(Pageable pageable);
 
+    @Query("""
+    SELECT new com.capstone.skill_service.dto.track.TrackOnlyResponseDto(
+        t.id,t.name,t.description,t.estimatedMonths,t.status,t.image,(SELECT COUNT(mc.growthTrack.id) FROM t.skillCapsules mc),
+        t.createdAt,t.updatedAt)
+    FROM GrowthTrackEntity t
+    WHERE (:name IS NULL OR LOWER(t.name) LIKE LOWER(CONCAT('%', :name, '%')))
+    """)
+    Page<TrackOnlyResponseDto> filterByNameContainingIgnoreCase(@Param("name") String name, Pageable pageable);
+
+
 }

--- a/src/main/java/com/capstone/skill_service/service/RouteService.java
+++ b/src/main/java/com/capstone/skill_service/service/RouteService.java
@@ -30,5 +30,6 @@ public interface RouteService {
     RouteResponseDto assignTrackToRoute(UUID routeId, TrackIdsRequestDto dto);
     void removeTrackFromRoute(UUID routeId, UUID trackId);
     RouteResponseDto reorderTracks(UUID routeId, List<UUID> orderedTrackIds);
+    CustomPageResponse<RouteResponseDto> filterByName(String name, Pageable pageable);
 
 }

--- a/src/main/java/com/capstone/skill_service/service/TrackService.java
+++ b/src/main/java/com/capstone/skill_service/service/TrackService.java
@@ -26,5 +26,6 @@ public interface TrackService {
     TrackResponseDto assignCapsuleToTrack(UUID trackId, CapsuleIdsRequestDto dto);
     void removeCapsuleFromTrack(UUID trackId, UUID capsuleId);
     TrackResponseDto reorderCapsules(UUID trackId, List<UUID> orderedCapsuleIds);
+    CustomPageResponse<TrackOnlyResponseDto> filterByName(String name, Pageable pageable);
 
 }

--- a/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/RouteServiceImpl.java
@@ -30,6 +30,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -496,5 +497,39 @@ public class RouteServiceImpl implements RouteService {
         }
         return routeMapper.toDto(routeRepository.save(route));
 
+    }
+
+    @Override
+    public CustomPageResponse<RouteResponseDto> filterByName(String name, Pageable pageable) {
+        Page<TalentRouteEntity> routeList;
+
+        if(name == null || name.trim().isEmpty()){
+            routeList = this.routeRepository.findAllWithGrowthTrack(PageRequest.of(0, 20));
+        }else{
+            routeList = this.routeRepository.filterByNameContainingIgnoreCase(name, pageable);
+        }
+
+        Page<RouteResponseDto> routes = routeList.map(this.routeMapper::toDto);
+
+        for(RouteResponseDto route: routes){
+            // generate presigned url
+            String imageUrl = FileHelper.getGeneratedPresignedUrl(this.routeMapper.toEntity(route),
+                    preSignedUrlService);
+            route.setImage(imageUrl);
+        }
+
+        logger.info("Talent route list is filtered");
+
+        return CustomPageResponse.<RouteResponseDto>builder()
+                .items(routes.getContent())
+                .pagination(PaginationData.builder()
+                        .page(routes.getNumber())
+                        .size(routes.getSize())
+                        .totalElements(routes.getTotalElements())
+                        .totalPages(routes.getTotalPages())
+                        .hasNext(routes.hasNext())
+                        .hasPrevious(routes.hasPrevious())
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/TrackServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -455,6 +456,38 @@ public class TrackServiceImpl implements TrackService {
         }
         return trackMapper.toDto(trackRepository.save(trackEntity));
 
+    }
+
+    @Override
+    public CustomPageResponse<TrackOnlyResponseDto> filterByName(String name, Pageable pageable) {
+        Page<TrackOnlyResponseDto> growthTracks;
+
+        if(name == null || name.trim().isEmpty()){
+            growthTracks = this.trackRepository.findTrackWithCapsuleCount(PageRequest.of(0, 20));
+        }else{
+            growthTracks = this.trackRepository.filterByNameContainingIgnoreCase(name, pageable);
+        }
+
+        for(TrackOnlyResponseDto growthTrack: growthTracks){
+            // generate presigned url
+            String imageUrl = FileHelper.getGeneratedPresignedUrl(this.trackMapper.toEntity(growthTrack),
+                    preSignedUrlService);
+            growthTrack.setImage(imageUrl);
+        }
+
+        logger.info("Growth tracks list is filtered");
+
+        return CustomPageResponse.<TrackOnlyResponseDto>builder()
+                .items(growthTracks.getContent())
+                .pagination(PaginationData.builder()
+                        .page(growthTracks.getNumber())
+                        .size(growthTracks.getSize())
+                        .totalElements(growthTracks.getTotalElements())
+                        .totalPages(growthTracks.getTotalPages())
+                        .hasNext(growthTracks.hasNext())
+                        .hasPrevious(growthTracks.hasPrevious())
+                        .build())
+                .build();
     }
 
 }


### PR DESCRIPTION
# 🚀 PR: Filter growth track and talent route by name 

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Skill taxonomy management.](https://amali-tech.atlassian.net/browse/VER-19)

---

## ✅ Summary

This PR adds some new functionalities and updates based on the frontend team's request.

---

## 📌 Features

- [x] Filter growth track by name
- [x] Filter talent route by name

## 🚧 Next Task

- Remove multiple capsules in the growth track in one go
- Remove multiple growth tracks in the talent route in one go
