### PR TITLE
Publish cluster creation event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>3.1.2</version>
+			<version>3.1.9</version>
 		</dependency>
 <!--		Kafka-->
 		<dependency>

--- a/src/main/java/com/capstone/skill_service/messaging/PopulateClusterEvents.java
+++ b/src/main/java/com/capstone/skill_service/messaging/PopulateClusterEvents.java
@@ -1,0 +1,26 @@
+package com.capstone.skill_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.ClusterEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PopulateClusterEvents {
+    private static final Logger logger = LoggerFactory.getLogger(PopulateClusterEvents.class);
+    private final KafkaTemplate<String, ClusterEvent> kafkaClusterTemplate;
+
+    @Value("${CLUSTER_CREATE_TOPIC}")
+    private String clusterCreateTopic;
+
+    public void populateCreateCluster(ClusterEvent clusterEvent){
+        kafkaClusterTemplate.send(clusterCreateTopic, clusterEvent);
+
+        logger.info("create cluster event is populated: {}", clusterEvent);
+    }
+
+}

--- a/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/CapsuleServiceImpl.java
@@ -110,6 +110,11 @@ public class CapsuleServiceImpl implements CapsuleService {
 
         }
 
+        // extract cluster ids
+        List<UUID> clusterIds = capsuleEntity.getClusters().stream()
+                .map(ClusterEntity::getId).toList();
+
+
         if(eventType.equalsIgnoreCase("delete")){
             populateSkillEvents.populateDeleteCapsule(SkillCapsuleEvent.builder()
                     .id(capsuleEntity.getId())
@@ -124,6 +129,7 @@ public class CapsuleServiceImpl implements CapsuleService {
                     .difficulty(capsuleEntity.getDifficulty())
                     .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
                     .skillAtom(listOfAtomsInCapsule)
+                    .clusters(clusterIds)
                     .build());
         }else if(eventType.equalsIgnoreCase("assignAtom")){
             populateSkillEvents.populateAssignCapsule(SkillCapsuleEvent.builder()
@@ -134,6 +140,7 @@ public class CapsuleServiceImpl implements CapsuleService {
                     .difficulty(capsuleEntity.getDifficulty())
                     .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
                     .skillAtom(listOfAtomsInCapsule)
+                    .clusters(clusterIds)
                     .build());
         }
         else{
@@ -145,6 +152,7 @@ public class CapsuleServiceImpl implements CapsuleService {
                     .difficulty(capsuleEntity.getDifficulty())
                     .proficiencyLevel(capsuleEntity.getProficiencyLevel().toString())
                     .skillAtom(listOfAtomsInCapsule)
+                    .clusters(clusterIds)
                     .build());
         }
 

--- a/src/main/java/com/capstone/skill_service/service/impl/ClusterServiceImpl.java
+++ b/src/main/java/com/capstone/skill_service/service/impl/ClusterServiceImpl.java
@@ -13,6 +13,7 @@ import com.capstone.skill_service.exception.ClusterExistsException;
 import com.capstone.skill_service.exception.ClusterNotFoundException;
 import com.capstone.skill_service.mapper.CapsuleMapper;
 import com.capstone.skill_service.mapper.ClusterMapper;
+import com.capstone.skill_service.messaging.PopulateClusterEvents;
 import com.capstone.skill_service.model.ClusterEntity;
 import com.capstone.skill_service.model.SkillCapsuleEntity;
 import com.capstone.skill_service.repository.*;
@@ -22,6 +23,7 @@ import com.capstone.skill_service.service.PreSignedUrlService;
 import com.capstone.skill_service.util.FileHelper;
 import com.capstone.skill_service.util.Status;
 import lombok.RequiredArgsConstructor;
+import org.common.event.ClusterEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
@@ -48,6 +50,7 @@ public class ClusterServiceImpl implements ClusterService {
     private final ClusterMapper clusterMapper;
     private final AwsFileUploadService awsFileUploadService;
     private final PreSignedUrlService preSignedUrlService;
+    private final PopulateClusterEvents populateClusterEvents;
 
     @Override
     @CacheEvict(value = "clusterList",allEntries = true)
@@ -78,6 +81,14 @@ public class ClusterServiceImpl implements ClusterService {
         FileHelper.generatePresignedUrl(saved, responseDto, preSignedUrlService);
 
         logger.info("Admin created skill cluster: {}", clusterEntity.getName());
+
+        // publish cluster event
+        ClusterEvent clusterEvent = ClusterEvent.builder()
+                .clusterId(saved.getId())
+                .clusterName(saved.getName())
+                .description(saved.getDescription())
+                .build();
+        populateClusterEvents.populateCreateCluster(clusterEvent);
 
         return responseDto;
     }


### PR DESCRIPTION
# 🚀 PR: Publish cluster creation event

### 🎫 Jira Ticket  
[🔗 SPRINT-1/VER-19: Skill taxonomy management.](https://amali-tech.atlassian.net/browse/VER-19)

---

## ✅ Summary

This PR introduces event publishing for the cluster entity.

---

## 📌 Features

- [x] Publish an event for cluster creation
- [x] Update capsule event payloads with cluster ids

## 🚧 Next Task

- Remove multiple capsules in the growth track in one go
- Remove multiple growth tracks in the talent route in one go
